### PR TITLE
Adds the capability to read molecules from tar.gz files

### DIFF
--- a/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
@@ -1,3 +1,4 @@
+import shutil
 import mpi4py
 
 mpi4py.rc.thread_level = "serialized"
@@ -30,6 +31,7 @@ from hydragnn.preprocess.load_data import split_dataset
 from hydragnn.utils.distdataset import DistDataset
 from hydragnn.utils.pickledataset import SimplePickleWriter, SimplePickleDataset
 from hydragnn.preprocess.utils import gather_deg
+from hydragnn.utils.tar_utils import extract_tar_file, get_mol_dir_list
 
 import numpy as np
 
@@ -77,7 +79,7 @@ def dftb_to_graph(moldir, dftb_node_types, var_config):
 class DFTBDataset(AbstractBaseDataset):
     """DFTBDataset dataset class"""
 
-    def __init__(self, dirpath, dftb_node_types, var_config, dist=False, sampling=None):
+    def __init__(self, dirpath, dftb_node_types, var_config, dist=False, sampling=None, tmpfs=None):
         super().__init__()
 
         self.dftb_node_types = dftb_node_types
@@ -114,11 +116,32 @@ class DFTBDataset(AbstractBaseDataset):
             dirlist = list(nsplit(dirlist, self.world_size))[self.rank]
             log("local dirlist", len(dirlist))
 
-        for subdir in iterate_tqdm(dirlist, verbosity_level=2, desc="Load"):
-            data_object = dftb_to_graph(
-                os.path.join(dirpath, subdir), dftb_node_types, var_config
-            )
-            self.dataset.append(data_object)
+        # Iterate through molecule directories or tar files and create graph objects
+        for item in iterate_tqdm(dirlist, verbosity_level=2, desc="Load"):
+            if 'readme' in item.lower(): continue
+            fullpath = os.path.join(dirpath, item)
+
+            # Verify that files in the directory are either tar.gz files or molecule directories
+            if (not fullpath.endswith(".tar.gz")) and (not os.path.isdir(fullpath)):
+                raise RuntimeError("Can't understand if {} is a molecule directory or tar.gz file".format(fullpath))
+
+            # If tar.gz files, extract tar file in a tmp dir
+            if fullpath.endswith(".tar.gz"):
+                if 'unprocessed' in os.path.basename(fullpath): continue
+                extract_path = extract_tar_file(fullpath, tmpfs)
+                mdirs = get_mol_dir_list(extract_path)
+                assert len(mdirs) > 0, f"No molecules found in tar file {fullpath} extracted at {extract_path}"
+                for mdir in mdirs:
+                    data_object = dftb_to_graph(mdir, dftb_node_types, var_config)
+                    self.dataset.append(data_object)
+
+                # Remove the temporary directory where the tar file was extracted
+                shutil.rmtree(extract_path)
+
+            # else if items in dirlist are molecule directories, parse them and create graph objects
+            else:
+                data_object = dftb_to_graph(fullpath, dftb_node_types, var_config)
+                self.dataset.append(data_object)
 
     def len(self):
         return len(self.dataset)
@@ -144,6 +167,14 @@ if __name__ == "__main__":
     parser.add_argument("--log", help="log name")
     parser.add_argument("--batch_size", type=int, help="batch_size", default=None)
     parser.add_argument("--everyone", action="store_true", help="gptimer")
+    parser.add_argument("--input_data", default=None,
+                        help="Input dataset to read in. Must be either a .txt file listing molecule directories or a "
+                             "directory containing .tar.gz files. Provide --tmpfs to extract tar files into fast, "
+                             "local storage.")
+    parser.add_argument("--tmpfs", default=None,
+                        help="Transient storage space such as /tmp/$USER which can be used as a temporary "
+                             "scratch space for caching and/or extracting data. "
+                             "The location must exist before use by HydraGNN.")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -166,7 +197,7 @@ if __name__ == "__main__":
     graph_feature_names = ["frequencies", "intensities"]
     graph_feature_dim = [50, 50]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
-    datafile = os.path.join(dirpwd, "dataset/dftb_aisd_electronic_excitation_spectrum")
+    datafile = args.input_data
     ##################################################################################################################
     input_filename = os.path.join(dirpwd, "dftb_discrete_uv_spectrum.json")
     ##################################################################################################################
@@ -211,10 +242,11 @@ if __name__ == "__main__":
     if args.preonly:
         ## local data
         total = DFTBDataset(
-            os.path.join(datafile, "mollist.txt"),
+            datafile,
             dftb_node_types,
             var_config,
             dist=True,
+            tmpfs=args.tmpfs,
         )
         trainset, valset, testset = split_dataset(
             dataset=total,

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -329,11 +329,9 @@ if __name__ == "__main__":
     ]
     var_config["graph_feature_names"] = graph_feature_names
     var_config["graph_feature_dims"] = graph_feature_dim
-    (
-        var_config["input_node_feature_names"],
-        var_config["input_node_feature_dims"],
-    ) = get_node_attribute_name(dftb_node_types)
-
+    var_config["node_feature_names"] = node_feature_names
+    var_config["node_feature_dims"] = node_feature_dims    
+    
     if args.batch_size is not None:
         config["NeuralNetwork"]["Training"]["batch_size"] = args.batch_size
     ##################################################################################################################

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -77,7 +77,7 @@ def dftb_to_graph(moldir, dftb_node_types, var_config):
     ytarget = np.loadtxt(spectrum_filename, usecols=1, dtype=np.float32)
     ytarget = torch.tensor(ytarget)
     data = generate_graphdata_from_rdkit_molecule(
-        mol, ytarget, dftb_node_types, var_config
+        mol, ytarget, dftb_node_types, var_config=var_config
     )
     data.ID = torch.tensor((int(os.path.basename(moldir).replace("mol_", "")),))
     return data
@@ -239,7 +239,7 @@ class DFTBDataset(AbstractBaseDataset):
             atomicdescriptors_torch_tensor = torch.cat([torch.tensor([descriptor]) for descriptor in atomic_descriptors_list],
                            dim=0).t().contiguous()
 
-        data_object = generate_graphdata_from_rdkit_molecule(mol, torch.tensor(spectrum_energies), dftb_node_types, atomicdescriptors_torch_tensor)
+        data_object = generate_graphdata_from_rdkit_molecule(mol, torch.tensor(spectrum_energies), dftb_node_types, atomicdescriptors_torch_tensor=atomicdescriptors_torch_tensor)
         atoms = io.read(dir + '/' + 'geo_end.xyz', parallel=False)
         data_object.pos = torch.from_numpy(atoms.positions)
         try:

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -163,7 +163,7 @@ class DFTBDataset(AbstractBaseDataset):
 
             # else if items in dirlist are molecule directories, parse them and create graph objects
             else:
-                data_object = self.transform_input_to_data_object_base(dirpath, mdir)
+                data_object = self.transform_input_to_data_object_base(dirpath, fullpath)
                 if data_object is not None:
                     self.dataset.append(data_object)
                     

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -329,8 +329,10 @@ if __name__ == "__main__":
     ]
     var_config["graph_feature_names"] = graph_feature_names
     var_config["graph_feature_dims"] = graph_feature_dim
-    var_config["node_feature_names"] = node_feature_names
-    var_config["node_feature_dims"] = node_feature_dims
+    (
+        var_config["input_node_feature_names"],
+        var_config["input_node_feature_dims"],
+    ) = get_node_attribute_name(dftb_node_types)
 
     if args.batch_size is not None:
         config["NeuralNetwork"]["Training"]["batch_size"] = args.batch_size

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -1,3 +1,4 @@
+import shutil
 import mpi4py
 
 mpi4py.rc.thread_level = "serialized"
@@ -38,6 +39,7 @@ from hydragnn.preprocess.load_data import split_dataset
 from hydragnn.utils.distdataset import DistDataset
 from hydragnn.utils.pickledataset import SimplePickleWriter, SimplePickleDataset
 from hydragnn.preprocess.utils import gather_deg
+from hydragnn.utils.tar_utils import extract_tar_file, get_mol_dir_list
 
 import numpy as np
 
@@ -84,7 +86,7 @@ def dftb_to_graph(moldir, dftb_node_types, var_config):
 class DFTBDataset(AbstractBaseDataset):
     """DFTBDataset dataset class"""
 
-    def __init__(self, dirpath, dftb_node_types, var_config, dist=False, sampling=None):
+    def __init__(self, dirpath, dftb_node_types, var_config, dist=False, sampling=None, tmpfs=None):
         super().__init__()
 
         # atomic descriptors
@@ -134,13 +136,37 @@ class DFTBDataset(AbstractBaseDataset):
             dirlist = list(nsplit(dirlist, self.world_size))[self.rank]
             log("local dirlist", len(dirlist))
 
-        for subdir in iterate_tqdm(dirlist, verbosity_level=2, desc="Load"):
-            data_object = self.transform_input_to_data_object_base(
-                dirpath, subdir
-            )
-            if data_object is not None:
-                self.dataset.append(data_object)
+        # Iterate through molecule directories or tar files and create graph objects
+        for item in iterate_tqdm(dirlist, verbosity_level=2, desc="Load"):
+            if 'readme' in item.lower(): continue
+            fullpath = os.path.join(dirpath, item)
 
+            # Verify that files in the directory are either tar.gz files or molecule directories
+            if (not fullpath.endswith(".tar.gz")) and (not os.path.isdir(fullpath)):
+                raise RuntimeError("Can't understand if {} is a molecule directory or tar.gz file".format(fullpath))
+
+            # If tar.gz files, extract tar file in a tmp dir
+            if fullpath.endswith(".tar.gz"):
+                if 'unprocessed' in os.path.basename(fullpath): continue
+                extract_path = extract_tar_file(fullpath, tmpfs)
+                mdirs = get_mol_dir_list(extract_path)
+                assert len(mdirs) > 0, f"No molecules found in tar file {fullpath} extracted at {extract_path}"
+                for mdir in mdirs:
+                    data_object = dftb_to_graph(mdir, dftb_node_types, var_config)
+                    self.dataset.append(data_object)
+                    data_object = self.transform_input_to_data_object_base(dirpath, mdir)
+                    if data_object is not None:
+                        self.dataset.append(data_object)
+
+                # Remove the temporary directory where the tar file was extracted
+                shutil.rmtree(extract_path)
+
+            # else if items in dirlist are molecule directories, parse them and create graph objects
+            else:
+                data_object = self.transform_input_to_data_object_base(dirpath, mdir)
+                if data_object is not None:
+                    self.dataset.append(data_object)
+                    
 
     def transform_input_to_data_object_base(self, raw_data_path, dir):
         data_object = self.__transform_DFTB_UV_input_to_data_object_base(raw_data_path, dir)
@@ -257,6 +283,14 @@ if __name__ == "__main__":
     parser.add_argument("--log", help="log name")
     parser.add_argument("--batch_size", type=int, help="batch_size", default=None)
     parser.add_argument("--everyone", action="store_true", help="gptimer")
+    parser.add_argument("--input_data", default=None,
+                        help="Input dataset to read in. Must be either a .txt file listing molecule directories or a "
+                             "directory containing .tar.gz files. Provide --tmpfs to extract tar files into fast, "
+                             "local storage.")
+    parser.add_argument("--tmpfs", default=None,
+                        help="Transient storage space such as /tmp/$USER which can be used as a temporary "
+                             "scratch space for caching and/or extracting data. "
+                             "The location must exist before use by HydraGNN.")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -281,7 +315,7 @@ if __name__ == "__main__":
     node_feature_names = ["atomic_features"]
     node_feature_dims = [16]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
-    datafile = os.path.join(dirpwd, "dataset/GDB-9-Ex-TDDFTB")
+    datafile = args.input_data
     ##################################################################################################################
     input_filename = os.path.join(dirpwd, "dftb_smooth_uv_spectrum.json")
     ##################################################################################################################
@@ -325,10 +359,11 @@ if __name__ == "__main__":
     if args.preonly:
         ## local data
         total = DFTBDataset(
-            os.path.join(datafile, "mollist.txt"),
+            datafile,
             dftb_node_types,
             var_config,
             dist=True,
+            tmpfs=args.tmpfs,
         )
         trainset, valset, testset = split_dataset(
             dataset=total,

--- a/hydragnn/utils/adiosdataset.py
+++ b/hydragnn/utils/adiosdataset.py
@@ -117,16 +117,9 @@ class AdiosWriter:
 
             if len(self.dataset[label]) > 0:
                 data = self.dataset[label][0]
-                geom_version = list(map(lambda x: int(x), torch_geometric.__version__.split('.')))
-                if geom_version[0] == 2 and geom_version[1] < 4:
-                    self.io.DefineAttribute("%s/keys" % label, data.keys)
-                    keys = sorted(data.keys)
-                elif geom_version[0] == 2 and geom_version[1] >= 4:
-                    self.io.DefineAttribute("%s/keys" % label, data.keys())
-                    keys = sorted(data.keys())
-                else:
-                    raise RuntimeError("pytorch geometric version is not supported: %s"%torch_geometric.__version__)
-
+                ## data.keys differs across different versions of geom
+                keys = sorted(data.keys()) if callable(data.keys) else sorted(data.keys)
+                self.io.DefineAttribute("%s/keys" % label, keys)
                 self.comm.allgather(keys)
 
             for k in keys:

--- a/hydragnn/utils/file_utils.py
+++ b/hydragnn/utils/file_utils.py
@@ -1,0 +1,7 @@
+import os
+
+
+def contains_subdirs(dirpath):
+    # Return True if there are subdirectories in dirpath
+    dirs = [f for f in os.scandir(dirpath) if f.is_dir()]
+    return True if len(dirs) > 0 else False

--- a/hydragnn/utils/smiles_utils.py
+++ b/hydragnn/utils/smiles_utils.py
@@ -114,7 +114,7 @@ def generate_graphdata_from_rdkit_molecule(
             var_config["type"],
             var_config["output_index"],
             var_config["graph_feature_dims"],
-            var_config["input_node_feature_dims"],
+            var_config["node_feature_dims"],
             data,
         )
 

--- a/hydragnn/utils/tar_utils.py
+++ b/hydragnn/utils/tar_utils.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+import traceback
+from file_utils import contains_subdirs
+
+
+def extract_tar_file(tar_file, dest, create_subdir=True):
+    """
+    Extract a tar_file at the destination location represented by 'dest'.
+    If dest is None, use the cwd as dest.
+    if create_subdir is True, create a subdirectory inside dest in which the tar file will be extracted.
+
+    Returns the dir path in which the tar file was extracted along with a list of molecule directories in
+    the tar file.
+    """
+
+    tarfname = os.path.basename(tar_file).split(".tar")[0]
+
+    # Set the destination directory based on input args
+    if dest is not None and create_subdir is True:
+        dest = os.path.join(os.path.abspath(dest), tarfname)
+    if dest is None:
+        dest = os.path.join(os.getcwd(), tarfname)
+
+    # Create the dest directory
+    os.makedirs(dest, exist_ok=True)
+
+    # Launch the tar command to extract the tar file
+    untar_cmd = "tar -xf {} -C {}".format(tar_file, dest)
+    p = subprocess.run(untar_cmd.split())
+    p.check_returncode()
+
+    return dest
+
+
+def get_mol_dir_list(tar_path):
+    """Get a list of molecule directories from the extracted tar
+
+    The tar may contain a list of molecule directories or a high-level directory that contains
+    molecule directories.
+    """
+    mol_dirs = [os.path.join(tar_path, mol_dir) for mol_dir in next(os.walk(tar_path))[1]]
+
+    # Extracted tar may contain a single high-level directories of mol directories
+    if len(mol_dirs) == 1 and contains_subdirs(mol_dirs[0]):
+        return get_mol_dir_list(mol_dirs[0])
+
+    return mol_dirs


### PR DESCRIPTION
Adds the capability to read molecules from tar.gz files in large datasets such as ornl_aisd_ex.

An input dataset can thus contain tar.gz files or molecule directories directly. The tar files will be distributed amongst process just as molecule directories are distributed for parallel processing.

Additional input arguments --datafile and --tmpfs are added. datafile can be 'mollist.txt'. tmpfs is recommended for use with tar.gz files to denote a temporary location where a tar.gz file can be extracted.