### PR TITLE
Add Lennard-Jones example

### DIFF
--- a/examples/LennardJones/LJ.json
+++ b/examples/LennardJones/LJ.json
@@ -66,5 +66,10 @@
         "learning_rate": 0.001
       }
     }
+  },
+  "Visualization": {
+     "plot_init_solution": true,
+     "plot_hist_solution": true,
+     "create_plots": true
   }
 }

--- a/examples/LennardJones/LJ_multitask.json
+++ b/examples/LennardJones/LJ_multitask.json
@@ -22,7 +22,7 @@
     "Architecture": {
       "periodic_boundary_conditions": true,
       "model_type": "EGNN",
-      "equivariance": true,
+      "equivariance": false,
       "edge_features": ["bond_length", "polar_angle", "azimutal_angle"],
       "max_neighbours": 20,
       "hidden_dim": 20,
@@ -33,13 +33,13 @@
           "dim_sharedlayers": 50,
           "num_headlayers": 2,
           "dim_headlayers": [
-            20,
-            20
+            260,
+            93
           ]
         },
         "node": {
-          "num_headlayers": 2,
-          "dim_headlayers": [20,20],
+          "num_headlayers": 1,
+          "dim_headlayers": [177],
           "type": "mlp"
         }
       },
@@ -59,8 +59,8 @@
       "output_names": ["total_energy", "atomic_forces"]
     },
     "Training": {
-      "num_epoch": 50,
-      "batch_size": 3,
+      "num_epoch": 1,
+      "batch_size": 64,
       "continue": 0,
       "EarlyStopping": true,
       "patience": 100,
@@ -71,5 +71,10 @@
         "learning_rate": 0.001
       }
     }
+  },
+  "Visualization": {
+     "plot_init_solution": true,
+     "plot_hist_solution": true,
+     "create_plots": true
   }
 }

--- a/examples/LennardJones/train_hpo.py
+++ b/examples/LennardJones/train_hpo.py
@@ -38,6 +38,12 @@ import torch.distributed as dist
 from hydragnn.utils import nsplit
 import hydragnn.utils.tracer as tr
 
+import pandas as pd
+import optuna
+
+torch.manual_seed(42)
+import random
+random.seed(42)
 
 # FIXME: this works fine for now because we train on disordered atomic structures with potentials and forces computed with Lennard-Jones
 
@@ -148,6 +154,126 @@ class LJDataset(AbstractBaseDataset):
 
     def get(self, idx):
         return self.dataset[idx]
+    
+
+def objective(trial):
+
+    global config, best_trial_id, best_validation_loss
+
+    # Extract the unique trial ID
+    trial_id = trial.number  # or trial_id = trial.trial_id
+
+    log_name = "MO2" if args.log is None else args.log
+    log_name = log_name + '_' + str(trial_id)
+    hydragnn.utils.setup_log(log_name)
+    writer = hydragnn.utils.get_summary_writer(log_name)
+
+    ## Set up logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%%(levelname)s (rank %d): %%(message)s" % (rank),
+        datefmt="%H:%M:%S",
+    )
+
+    # Define the search space for hyperparameters
+    model_type = trial.suggest_categorical('model_type', ['EGNN']) #, 'SchNet'
+    hidden_dim = trial.suggest_int('hidden_dim', 50, 300)
+    num_conv_layers = trial.suggest_int('num_conv_layers', 1, 5)
+    num_headlayers = trial.suggest_int('num_headlayers', 1, 3)
+    dim_headlayers = [trial.suggest_int(f'dim_headlayer_{i}', 50, 300) for i in range(num_headlayers)]
+    lr = trial.suggest_float('lr', 1.0, 5.0)
+    batch_size = trial.suggest_categorical('batch_size', [1, 2, 4, 8, 16, 32, 64])
+
+    # Update the config dictionary with the suggested hyperparameters
+    config["NeuralNetwork"]["Architecture"]["model_type"] = model_type
+    config["NeuralNetwork"]["Architecture"]["hidden_dim"] = hidden_dim
+    config["NeuralNetwork"]["Architecture"]["num_conv_layers"] = num_conv_layers
+    #config["NeuralNetwork"]["Architecture"]["output_heads"]["node"]["num_headlayers"] = num_headlayers
+    #config["NeuralNetwork"]["Architecture"]["output_heads"]["node"]["dim_headlayers"] = dim_headlayers
+    config["NeuralNetwork"]["Architecture"]["output_heads"]["graph"]["num_headlayers"] = num_headlayers
+    config["NeuralNetwork"]["Architecture"]["output_heads"]["graph"]["dim_headlayers"] = dim_headlayers
+    config["NeuralNetwork"]["Training"]["Optimizer"]["learning_rate"] = 10**-lr
+    config["NeuralNetwork"]["Training"]["batch_size"] = batch_size
+
+    if model_type not in ['EGNN', 'SchNet', 'DimeNet']:
+        config["NeuralNetwork"]["Architecture"]["equivariance"] = False
+
+
+    (train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
+        trainset, valset, testset, config["NeuralNetwork"]["Training"]["batch_size"]
+    )
+
+    config = hydragnn.utils.update_config(config, train_loader, val_loader, test_loader)
+    ## Good to sync with everyone right after DDStore setup
+    comm.Barrier()
+
+    hydragnn.utils.save_config(config, log_name)
+
+    model = hydragnn.models.create_model_config(
+        config=config["NeuralNetwork"],
+        verbosity=verbosity,
+    )
+    model = hydragnn.utils.get_distributed_model(model, verbosity)
+
+    learning_rate = config["NeuralNetwork"]["Training"]["Optimizer"]["learning_rate"]
+    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", factor=0.5, patience=5, min_lr=0.00001
+    )
+
+    hydragnn.utils.load_existing_model_config(
+        model, config["NeuralNetwork"]["Training"], optimizer=optimizer
+    )
+
+    ##################################################################################################################
+
+    hydragnn.train.train_validate_test(
+        model,
+        optimizer,
+        train_loader,
+        val_loader,
+        test_loader,
+        writer,
+        scheduler,
+        config["NeuralNetwork"],
+        log_name,
+        verbosity,
+        create_plots=config["Visualization"]["create_plots"]
+    )
+
+    hydragnn.utils.save_model(model, optimizer, log_name)
+    hydragnn.utils.print_timers(verbosity)
+
+    """
+    if tr.has("GPTLTracer"):
+        import gptl4py as gp
+
+        eligible = rank if args.everyone else 0
+        if rank == eligible:
+            gp.pr_file(os.path.join("logs", log_name, "gp_timing.p%d" % rank))
+        gp.pr_summary_file(os.path.join("logs", log_name, "gp_timing.summary"))
+        gp.finalize()
+    """
+
+    # Return the metric to minimize (e.g., validation loss)
+    validation_loss, tasks_loss = hydragnn.train.validate(val_loader, model, verbosity, reduce_ranks=True)
+
+    # Move validation_loss to the CPU and convert to NumPy object
+    validation_loss = validation_loss.cpu().detach().numpy()
+
+    # Append trial results to the DataFrame
+    trial_results.loc[trial_id] = [trial_id, hidden_dim, num_conv_layers, num_headlayers, dim_headlayers, model_type, learning_rate, batch_size, validation_loss]
+    # trial_results.loc[trial_id] = [trial_id, alpha_values, validation_loss]
+    # trial_results.loc[trial_id] = [trial_id, mu, validation_loss]
+
+    # Update information about the best trial
+    if validation_loss < best_validation_loss:
+        best_validation_loss = validation_loss
+        best_trial_id = trial_id
+
+    # Return the metric to minimize (e.g., validation loss)
+    return validation_loss
+
 
 
 if __name__ == "__main__":
@@ -325,69 +451,41 @@ if __name__ == "__main__":
             trainset.pna_deg = pna_deg
     else:
         raise NotImplementedError("No supported format: %s" % (args.format))
-
-    info(
-        "trainset,valset,testset size: %d %d %d"
-        % (len(trainset), len(valset), len(testset))
-    )
-
-    if args.ddstore:
-        os.environ["HYDRAGNN_AGGR_BACKEND"] = "mpi"
-        os.environ["HYDRAGNN_USE_ddstore"] = "1"
-
-    (train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
-        trainset, valset, testset, config["NeuralNetwork"]["Training"]["batch_size"]
-    )
-
-    config = hydragnn.utils.update_config(config, train_loader, val_loader, test_loader)
-    ## Good to sync with everyone right after DDStore setup
-    comm.Barrier()
-
-    hydragnn.utils.save_config(config, log_name)
-
+    
     timer.stop()
+    # Choose the sampler (e.g., TPESampler or RandomSampler)
+    sampler = optuna.samplers.TPESampler(consider_prior=True, consider_magic_clip=False)
+    # sampler = optuna.samplers.RandomSampler()
+    # sampler = optuna.samplers.CmaEsSampler(cma_stds=[1.0, 1.0, 1.0], consider_pruned_trials=True, consider_prior=False)
+    # sampler = optuna.samplers.GridSampler(consider_prior=False)
+    # sampler = optuna.samplers.NSGAIISampler(pop_size=100, crossover_prob=0.9, mutation_prob=0.1)
 
-    model = hydragnn.models.create_model_config(
-        config=config["NeuralNetwork"],
-        verbosity=verbosity,
-    )
-    model = hydragnn.utils.get_distributed_model(model, verbosity)
+    # Create an empty DataFrame to store trial results
+    trial_results = pd.DataFrame(columns=['Trial_ID', 'Hidden_Dim', 'Num_Conv_Layers', 'Num_Headlayers', 'Dim_Headlayers', 'Model_Type', 'LR', 'Batch_Size', 'Validation_Loss'])
 
-    learning_rate = config["NeuralNetwork"]["Training"]["Optimizer"]["learning_rate"]
-    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, mode="min", factor=0.5, patience=5, min_lr=0.00001
-    )
+    # Variables to store information about the best trial
+    best_trial_id = None
+    best_validation_loss = float('inf')
 
-    hydragnn.utils.load_existing_model_config(
-        model, config["NeuralNetwork"]["Training"], optimizer=optimizer
-    )
+    # Create a study object and optimize the objective function
+    study = optuna.create_study(direction='minimize')
+    study.optimize(objective, n_trials=3)
 
-    ##################################################################################################################
+    # Update the best trial information directly within the DataFrame
+    best_trial_info = pd.Series({'Trial_ID': best_trial_id, 'Best_Validation_Loss': best_validation_loss})
+    trial_results = pd.concat([trial_results, best_trial_info.to_frame().T], ignore_index=True)
 
-    hydragnn.train.train_validate_test(
-        model,
-        optimizer,
-        train_loader,
-        val_loader,
-        test_loader,
-        writer,
-        scheduler,
-        config["NeuralNetwork"],
-        log_name,
-        verbosity,
-        create_plots=config["Visualization"]["create_plots"],
-    )
+    # Save the trial results to a CSV file
+    trial_results.to_csv('hpo_results.csv', index=False)
 
-    hydragnn.utils.save_model(model, optimizer, log_name)
-    hydragnn.utils.print_timers(verbosity)
+    # Get the best hyperparameters and corresponding trial ID
+    best_params = study.best_params
+    print("Best Hyperparameters:", best_params)
 
-    if tr.has("GPTLTracer"):
-        import gptl4py as gp
+    best_trial_id = study.best_trial.number  # or best_trial_id = study.best_trial.trial_id
 
-        eligible = rank if args.everyone else 0
-        if rank == eligible:
-            gp.pr_file(os.path.join("logs", log_name, "gp_timing.p%d" % rank))
-        gp.pr_summary_file(os.path.join("logs", log_name, "gp_timing.summary"))
-        gp.finalize()
+    # Print information about the best trial
+    print("Best Trial ID:", best_trial_id)
+    print("Best Validation Loss:", best_validation_loss)
+
     sys.exit(0)


### PR DESCRIPTION
Add new Lennard-Jones example directory from another branch:

- Different JSON config files for different MTL/STL model architectures
- `train.py` script to process dataset and train based off config file
- `inference.py` and `inference_derivative_energy.py` scripts to predict inference on outputs and specifically negative gradient of energy to force comparison
- `train_hpo.py` script for Optuna-based hyper parameter optimization
- Other training scripts