### PR TITLE
Fix precision side effect in create_model_config causing mixed-dtype overhead

### DIFF
--- a/examples/multidataset_hpo_sc26/inference_fused.py
+++ b/examples/multidataset_hpo_sc26/inference_fused.py
@@ -379,6 +379,8 @@ def main():
         config=config["NeuralNetwork"],
         verbosity=config["Verbosity"]["level"],
     )
+    # Restore default dtype: create_model_config overwrites it with the training precision.
+    torch.set_default_dtype(param_dtype)
     model = model.to(dtype=param_dtype, device=device)
 
     ckpt_path = _find_checkpoint(args.logdir, args.checkpoint)

--- a/examples/multidataset_hpo_sc26/inference_random_structures.py
+++ b/examples/multidataset_hpo_sc26/inference_random_structures.py
@@ -191,6 +191,8 @@ def main():
         config=config["NeuralNetwork"],
         verbosity=config["Verbosity"]["level"],
     )
+    # Restore default dtype: create_model_config overwrites it with the training precision.
+    torch.set_default_dtype(param_dtype)
     model = model.to(dtype=param_dtype, device=device)
 
     ckpt_path = _find_checkpoint(args.logdir, args.checkpoint)

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -456,7 +456,9 @@ class Base(Module):
     def _embedding(self, data):
         if not hasattr(data, "edge_shifts"):
             data.edge_shifts = torch.zeros(
-                (data.edge_index.size(1), 3), device=data.edge_index.device
+                (data.edge_index.size(1), 3),
+                device=data.edge_index.device,
+                dtype=data.pos.dtype,
             )
         conv_args = {"edge_index": data.edge_index.to(torch.long)}
         if self.use_edge_attr:
@@ -470,7 +472,7 @@ class Base(Module):
             x = self.pos_emb(data.pe)
             # if node features are available, generate mebeddings, concatenate with positional embeddings and map to hidden dim
             if self.input_dim:
-                x = torch.cat((self.node_emb(data.x.float()), x), 1)
+                x = torch.cat((self.node_emb(data.x), x), 1)
                 x = self.node_lin(x)
             # repeat for edge features and relative edge encodings
             if self.is_edge_model:

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -103,9 +103,12 @@ def create_model_config(
     ## Set precision: bf16, fp32, fp64
     training_cfg = config["Training"]
     precision, param_dtype, _ = resolve_precision(training_cfg.get("precision", "fp32"))
+    prev_dtype = torch.get_default_dtype()
     torch.set_default_dtype(param_dtype)
+    model = model.to(dtype=param_dtype)
+    torch.set_default_dtype(prev_dtype)
 
-    return model.to(dtype=param_dtype)
+    return model
 
 
 # FIXME: interface does not include ilossweights_hyperp, ilossweights_nll, dropout


### PR DESCRIPTION
create_model_config() calls torch.set_default_dtype() as a side effect, overriding the caller's intended precision. When inferring in FP32/BF16 with a model trained in FP64, this caused all intermediate tensors to be created in FP64 while model params were FP32, triggering constant dtype promotion and making FP32 slower than FP64.

Changes:
- create.py: save/restore torch.set_default_dtype around create_model_config
- inference_fused.py, inference_random_structures.py: re-set default dtype after create_model_config to guard against the side effect
- Base.py: use param_dtype instead of hardcoded .float() in _embedding