### PR TITLE
Code for training the MLP.

### DIFF
--- a/examples/multidataset_hpo_sc26/branch_weighting_mlp_cached.py
+++ b/examples/multidataset_hpo_sc26/branch_weighting_mlp_cached.py
@@ -161,17 +161,23 @@ def _collect_records(
             energy_preds_stacked, forces_preds_stacked, data.batch, dataset_ids
         )
 
-        records.append({
-            "comp": comp.detach().to(dtype=cache_dtype).cpu(),
-            "dataset_ids": dataset_ids.detach().to(dtype=torch.long).cpu(),
-            "energy_target": energy_target.detach().to(dtype=cache_dtype).cpu(),
-            "forces_target": forces_target.detach().to(dtype=cache_dtype).cpu(),
-            "batch": data.batch.detach().to(dtype=torch.long).cpu(),
-            "energy_preds": energy_preds_stacked.detach().to(dtype=cache_dtype).cpu(),
-            "forces_preds": forces_preds_stacked.detach().to(dtype=cache_dtype).cpu(),
-            "num_graphs": int(data.num_graphs),
-            "num_branches": int(num_branches),
-        })
+        records.append(
+            {
+                "comp": comp.detach().to(dtype=cache_dtype).cpu(),
+                "dataset_ids": dataset_ids.detach().to(dtype=torch.long).cpu(),
+                "energy_target": energy_target.detach().to(dtype=cache_dtype).cpu(),
+                "forces_target": forces_target.detach().to(dtype=cache_dtype).cpu(),
+                "batch": data.batch.detach().to(dtype=torch.long).cpu(),
+                "energy_preds": energy_preds_stacked.detach()
+                .to(dtype=cache_dtype)
+                .cpu(),
+                "forces_preds": forces_preds_stacked.detach()
+                .to(dtype=cache_dtype)
+                .cpu(),
+                "num_graphs": int(data.num_graphs),
+                "num_branches": int(num_branches),
+            }
+        )
 
     return records
 
@@ -414,13 +420,17 @@ def main():
     args_tiny.num_samples = 100
     args_tiny.preload = False
     first_train_loader, first_val_loader, _ = load_single_dataset_dataloaders(
-        args_tiny, config, var_config,
+        args_tiny,
+        config,
+        var_config,
         model_name=modellist[0],
         model_index=0,
         modellist=modellist,
         pna_deg=pna_deg,
     )
-    config = update_config(config, first_train_loader, first_val_loader, first_val_loader)
+    config = update_config(
+        config, first_train_loader, first_val_loader, first_val_loader
+    )
     del first_train_loader, first_val_loader
     gc.collect()
 
@@ -460,24 +470,34 @@ def main():
     total_train_cached = 0
     total_val_cached = 0
 
-    chunk_size = args.chunk_size or (args.num_samples or 10**9)
+    chunk_size = args.chunk_size or (args.num_samples or 10 ** 9)
 
     for model_index, model_name in enumerate(modellist):
         if rank == 0:
             print(f"Caching dataset {model_index + 1}/{len(modellist)}: {model_name}")
 
         dataset_cache_dir = os.path.join(args.cache_dir, model_name)
-        out_train = os.path.join(dataset_cache_dir, "train", f"rank{rank:05d}", "batches.pkl")
-        out_val   = os.path.join(dataset_cache_dir, "val",   f"rank{rank:05d}", "batches.pkl")
+        out_train = os.path.join(
+            dataset_cache_dir, "train", f"rank{rank:05d}", "batches.pkl"
+        )
+        out_val = os.path.join(
+            dataset_cache_dir, "val", f"rank{rank:05d}", "batches.pkl"
+        )
 
         # Skip entirely if both splits already cached
-        if (not args.rebuild_cache) and os.path.exists(out_train) and os.path.exists(out_val):
+        if (
+            (not args.rebuild_cache)
+            and os.path.exists(out_train)
+            and os.path.exists(out_val)
+        ):
             n_train = _count_chunks(out_train)
-            n_val   = _count_chunks(out_val)
+            n_val = _count_chunks(out_val)
             if rank == 0:
-                print(f"  Already cached ({n_train} train chunks, {n_val} val chunks), skipping")
+                print(
+                    f"  Already cached ({n_train} train chunks, {n_val} val chunks), skipping"
+                )
             total_train_cached += n_train
-            total_val_cached   += n_val
+            total_val_cached += n_val
             if dist.is_available() and dist.is_initialized():
                 dist.barrier()
             continue
@@ -489,18 +509,20 @@ def main():
                     os.remove(p)
 
         os.makedirs(os.path.dirname(out_train), exist_ok=True)
-        os.makedirs(os.path.dirname(out_val),   exist_ok=True)
+        os.makedirs(os.path.dirname(out_val), exist_ok=True)
 
-        num_samples = args.num_samples or 10**9
+        num_samples = args.num_samples or 10 ** 9
         train_batches_written = 0
-        val_batches_written   = 0
+        val_batches_written = 0
 
         for chunk_start in range(0, num_samples, chunk_size):
             if rank == 0:
                 print(f"  Chunk [{chunk_start} : {chunk_start + chunk_size}]")
 
             train_loader, val_loader, _ = load_single_dataset_chunk(
-                args, config, var_config,
+                args,
+                config,
+                var_config,
                 model_name=model_name,
                 model_index=model_index,
                 modellist=modellist,
@@ -510,13 +532,25 @@ def main():
             )
 
             train_records = _collect_records(
-                model, train_loader, num_branches, precision, cache_dtype, param_dtype, device
+                model,
+                train_loader,
+                num_branches,
+                precision,
+                cache_dtype,
+                param_dtype,
+                device,
             )
             _append_records(out_train, train_records)
             train_batches_written += len(train_records)
 
             val_records = _collect_records(
-                model, val_loader, num_branches, precision, cache_dtype, param_dtype, device
+                model,
+                val_loader,
+                num_branches,
+                precision,
+                cache_dtype,
+                param_dtype,
+                device,
             )
             _append_records(out_val, val_records)
             val_batches_written += len(val_records)
@@ -528,10 +562,12 @@ def main():
                 dist.barrier()
 
         if rank == 0:
-            print(f"  Saved {train_batches_written} train, {val_batches_written} val batches")
+            print(
+                f"  Saved {train_batches_written} train, {val_batches_written} val batches"
+            )
 
         total_train_cached += train_batches_written
-        total_val_cached   += val_batches_written
+        total_val_cached += val_batches_written
 
         if dist.is_available() and dist.is_initialized():
             dist.barrier()
@@ -553,12 +589,14 @@ def main():
     # MLP training
     # ------------------------------------------------------------------
     train_cache_files = _get_rank_cache_files(args.cache_dir, split="train")
-    val_cache_files   = _get_rank_cache_files(args.cache_dir, split="val")
+    val_cache_files = _get_rank_cache_files(args.cache_dir, split="val")
     if len(train_cache_files) == 0 or len(val_cache_files) == 0:
         raise RuntimeError("Cache files are missing; run with --rebuild_cache")
 
     if rank == 0:
-        print(f"MLP training on {len(train_cache_files)} train files, {len(val_cache_files)} val files per rank")
+        print(
+            f"MLP training on {len(train_cache_files)} train files, {len(val_cache_files)} val files per rank"
+        )
 
     hidden_dims = tuple(int(x) for x in args.hidden_dims.split(",") if x.strip())
     mlp = BranchWeightMLP(None, hidden_dims, num_branches).to(
@@ -624,7 +662,9 @@ def main():
             with open(timing_path, "r") as f:
                 timing_history = json.load(f)
             if rank == 0:
-                print(f"Loaded timing history ({len(timing_history)} epochs) from {timing_path}")
+                print(
+                    f"Loaded timing history ({len(timing_history)} epochs) from {timing_path}"
+                )
         except Exception:
             timing_history = []
 
@@ -639,23 +679,34 @@ def main():
         random.shuffle(train_cache_files)
 
         train_loss, train_timing = _train_epoch_from_cache(
-            mlp, train_cache_files, optimizer, loss_fn,
-            energy_weight, force_weight, top_k, precision,
+            mlp,
+            train_cache_files,
+            optimizer,
+            loss_fn,
+            energy_weight,
+            force_weight,
+            top_k,
+            precision,
         )
 
         if dist.is_available() and dist.is_initialized():
             dist.barrier()
 
         val_loss, val_timing = _validate_epoch_from_cache(
-            mlp, val_cache_files, loss_fn,
-            energy_weight, force_weight, top_k, precision,
+            mlp,
+            val_cache_files,
+            loss_fn,
+            energy_weight,
+            force_weight,
+            top_k,
+            precision,
         )
 
         if dist.is_available() and dist.is_initialized():
             dist.barrier()
 
         train_loss_global = _allreduce_mean(train_loss)
-        val_loss_global   = _allreduce_mean(val_loss)
+        val_loss_global = _allreduce_mean(val_loss)
 
         scheduler.step(val_loss_global)
 
@@ -669,7 +720,7 @@ def main():
                 "train_loss": float(train_loss_global),
                 "val_loss": float(val_loss_global),
                 "train_timing": {k: float(v) for k, v in train_timing.items()},
-                "val_timing":   {k: float(v) for k, v in val_timing.items()},
+                "val_timing": {k: float(v) for k, v in val_timing.items()},
             }
         )
 

--- a/examples/multidataset_hpo_sc26/branch_weighting_mlp_cached.py
+++ b/examples/multidataset_hpo_sc26/branch_weighting_mlp_cached.py
@@ -7,15 +7,20 @@ Workflow:
 """
 
 import argparse
+import copy
 import glob
 import json
 import os
+import pickle
+import random
 import time
-from typing import Dict, Tuple
+import gc
+from typing import Dict, List, Tuple
 
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
 
 import hydragnn
 from hydragnn.models.create import create_model_config
@@ -25,6 +30,7 @@ from hydragnn.utils.input_config_parsing.config_utils import update_config
 from hydragnn.utils.print.print_utils import iterate_tqdm
 
 from branch_weighting_mlp import BranchWeightMLP
+from branch_weighting_mlp import _reshape_composition
 
 try:
     from .utils import (
@@ -33,6 +39,9 @@ try:
         resolve_selected_precision,
         infer_num_branches,
         load_multidataset_dataloaders,
+        load_single_dataset_dataloaders,
+        load_single_dataset_chunk,
+        get_modellist_and_pna_deg,
         predict_branch_energy_forces,
         weighted_average,
         extract_dataset_ids,
@@ -45,6 +54,9 @@ except ImportError:
         resolve_selected_precision,
         infer_num_branches,
         load_multidataset_dataloaders,
+        load_single_dataset_dataloaders,
+        load_single_dataset_chunk,
+        get_modellist_and_pna_deg,
         predict_branch_energy_forces,
         weighted_average,
         extract_dataset_ids,
@@ -83,52 +95,54 @@ def _resolve_weights_from_logits(logits: torch.Tensor, top_k: int) -> torch.Tens
     return F.softmax(sparse_logits, dim=-1)
 
 
-def _prepare_rank_dir(path: str, clear_existing: bool):
-    os.makedirs(path, exist_ok=True)
-    if not clear_existing:
-        return
-    for file_path in glob.glob(os.path.join(path, "*.pt")):
-        os.remove(file_path)
+def _append_records(path: str, records: list):
+    """Append a list of records to a pickle file, creating it if needed."""
+    with open(path, "ab") as f:
+        pickle.dump(records, f, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def _cache_split(
+def _iter_records(path: str):
+    """Stream records from a pickle file one chunk at a time — no full-file RAM load."""
+    with open(path, "rb") as f:
+        while True:
+            try:
+                records = pickle.load(f)
+                yield from records
+            except EOFError:
+                break
+
+
+def _count_chunks(path: str) -> int:
+    """Count how many chunks have been appended to a pickle file."""
+    count = 0
+    with open(path, "rb") as f:
+        while True:
+            try:
+                pickle.load(f)
+                count += 1
+            except EOFError:
+                break
+    return count
+
+
+def _collect_records(
     model,
     loader,
-    split: str,
-    cache_root: str,
     num_branches: int,
     precision: str,
     cache_dtype: torch.dtype,
-    rebuild_cache: bool,
-) -> int:
-    device = get_device()
-    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
-    _, param_dtype, _ = resolve_precision(precision)
-
-    rank_dir = os.path.join(cache_root, split, f"rank{rank:05d}")
-    _prepare_rank_dir(rank_dir, clear_existing=rebuild_cache)
-
-    if (not rebuild_cache) and len(glob.glob(os.path.join(rank_dir, "*.pt"))) > 0:
-        return len(glob.glob(os.path.join(rank_dir, "*.pt")))
-
-    num_files = 0
+    param_dtype,
+    device,
+) -> list:
+    """Run HydraGNN inference on all batches in loader and return list of records."""
+    records = []
     model.eval()
-    for batch_idx, data in enumerate(
-        iterate_tqdm(loader, 2, desc=f"Cache {split}", leave=False)
-    ):
+    for data in iterate_tqdm(loader, 2, desc="Inference", leave=False):
         data = move_batch_to_device(data, param_dtype)
         data.pos.requires_grad_(True)
 
-        comp = data.chemical_composition
-        if comp.dim() == 1:
-            comp = comp.unsqueeze(0)
-        elif (
-            comp.dim() == 2
-            and comp.size(0) != data.num_graphs
-            and comp.size(1) == data.num_graphs
-        ):
-            comp = comp.t()
-        comp = comp.to(device=device, dtype=param_dtype)
+        comp = _reshape_composition(data).to(device=device, dtype=param_dtype)
+
         energy_preds = []
         forces_preds = []
         with torch.enable_grad():
@@ -141,12 +155,13 @@ def _cache_split(
 
         energy_preds_stacked = torch.stack(energy_preds, dim=0)
         forces_preds_stacked = torch.stack(forces_preds, dim=0)
+
         dataset_ids = extract_dataset_ids(data, num_branches)
         energy_target, forces_target = teacher_from_dataset_id(
             energy_preds_stacked, forces_preds_stacked, data.batch, dataset_ids
         )
 
-        record = {
+        records.append({
             "comp": comp.detach().to(dtype=cache_dtype).cpu(),
             "dataset_ids": dataset_ids.detach().to(dtype=torch.long).cpu(),
             "energy_target": energy_target.detach().to(dtype=cache_dtype).cpu(),
@@ -156,30 +171,34 @@ def _cache_split(
             "forces_preds": forces_preds_stacked.detach().to(dtype=cache_dtype).cpu(),
             "num_graphs": int(data.num_graphs),
             "num_branches": int(num_branches),
-        }
-        out_path = os.path.join(rank_dir, f"batch_{batch_idx:07d}.pt")
-        torch.save(record, out_path)
-        num_files += 1
+        })
 
-    return num_files
+    return records
 
 
-def _get_rank_cache_files(cache_root: str, split: str):
+def _get_rank_cache_files(cache_root: str, split: str) -> List[str]:
+    """Collect all batches.pkl files across all dataset subdirectories."""
     rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
-    rank_dir = os.path.join(cache_root, split, f"rank{rank:05d}")
-    files = sorted(glob.glob(os.path.join(rank_dir, "batch_*.pt")))
-    return files
+    all_files = []
+    if not os.path.isdir(cache_root):
+        return all_files
+    for dataset_dir in sorted(os.listdir(cache_root)):
+        rank_dir = os.path.join(cache_root, dataset_dir, split, f"rank{rank:05d}")
+        f = os.path.join(rank_dir, "batches.pkl")
+        if os.path.exists(f):
+            all_files.append(f)
+    return all_files
 
 
 def _train_epoch_from_cache(
     mlp,
-    cache_files,
+    cache_files: List[str],
     optimizer,
     loss_fn,
-    energy_weight,
-    force_weight,
-    top_k,
-    precision,
+    energy_weight: float,
+    force_weight: float,
+    top_k: int,
+    precision: str,
 ) -> Tuple[float, Dict[str, float]]:
     mlp.train()
     device = get_device()
@@ -188,58 +207,57 @@ def _train_epoch_from_cache(
     total_loss = 0.0
     total_samples = 0
     timing = {"total": 0.0, "load": 0.0, "mlp": 0.0, "loss": 0.0, "opt": 0.0}
+    total_batches = 0
 
     for cache_file in iterate_tqdm(cache_files, 2, desc="Cached train", leave=False):
         iter_t0 = time.perf_counter()
 
-        t0 = time.perf_counter()
-        record = torch.load(cache_file, map_location="cpu")
-        timing["load"] += time.perf_counter() - t0
+        for record in _iter_records(cache_file):
+            t0 = time.perf_counter()
+            comp = record["comp"].to(device=device, dtype=param_dtype)
+            logits = mlp(comp)
+            weights = _resolve_weights_from_logits(logits, top_k=top_k)
+            timing["mlp"] += time.perf_counter() - t0
 
-        t0 = time.perf_counter()
-        comp = record["comp"].to(device=device, dtype=param_dtype)
-        logits = mlp(comp)
-        weights = _resolve_weights_from_logits(logits, top_k=top_k)
-        timing["mlp"] += time.perf_counter() - t0
+            t0 = time.perf_counter()
+            energy_preds = record["energy_preds"].to(device=device, dtype=param_dtype)
+            forces_preds = record["forces_preds"].to(device=device, dtype=param_dtype)
+            batch = record["batch"].to(device=device, dtype=torch.long)
+            weighted_energy, weighted_forces = weighted_average(
+                energy_preds, forces_preds, weights, batch
+            )
+            energy_target = record["energy_target"].to(device=device, dtype=param_dtype)
+            forces_target = record["forces_target"].to(device=device, dtype=param_dtype)
+            loss_energy = loss_fn(weighted_energy, energy_target)
+            loss_forces = loss_fn(weighted_forces, forces_target)
+            loss = energy_weight * loss_energy + force_weight * loss_forces
+            timing["loss"] += time.perf_counter() - t0
 
-        t0 = time.perf_counter()
-        energy_preds = record["energy_preds"].to(device=device, dtype=param_dtype)
-        forces_preds = record["forces_preds"].to(device=device, dtype=param_dtype)
-        batch = record["batch"].to(device=device, dtype=torch.long)
-        weighted_energy, weighted_forces = weighted_average(
-            energy_preds, forces_preds, weights, batch
-        )
-        energy_target = record["energy_target"].to(device=device, dtype=param_dtype)
-        forces_target = record["forces_target"].to(device=device, dtype=param_dtype)
-        loss_energy = loss_fn(weighted_energy, energy_target)
-        loss_forces = loss_fn(weighted_forces, forces_target)
-        loss = energy_weight * loss_energy + force_weight * loss_forces
-        timing["loss"] += time.perf_counter() - t0
+            t0 = time.perf_counter()
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            timing["opt"] += time.perf_counter() - t0
 
-        t0 = time.perf_counter()
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
-        timing["opt"] += time.perf_counter() - t0
+            total_loss += loss.item() * int(record["num_graphs"])
+            total_samples += int(record["num_graphs"])
+            total_batches += 1
 
-        num_graphs = int(record["num_graphs"])
-        total_loss += loss.item() * num_graphs
-        total_samples += num_graphs
         timing["total"] += time.perf_counter() - iter_t0
 
-    timing["num_batches"] = max(len(cache_files), 1)
+    timing["num_batches"] = max(total_batches, 1)
     return total_loss / max(total_samples, 1), timing
 
 
 @torch.no_grad()
 def _validate_epoch_from_cache(
     mlp,
-    cache_files,
+    cache_files: List[str],
     loss_fn,
-    energy_weight,
-    force_weight,
-    top_k,
-    precision,
+    energy_weight: float,
+    force_weight: float,
+    top_k: int,
+    precision: str,
 ) -> Tuple[float, Dict[str, float]]:
     mlp.eval()
     device = get_device()
@@ -248,40 +266,39 @@ def _validate_epoch_from_cache(
     total_loss = 0.0
     total_samples = 0
     timing = {"total": 0.0, "load": 0.0, "mlp": 0.0, "loss": 0.0}
+    total_batches = 0
 
     for cache_file in iterate_tqdm(cache_files, 2, desc="Cached val", leave=False):
         iter_t0 = time.perf_counter()
 
-        t0 = time.perf_counter()
-        record = torch.load(cache_file, map_location="cpu")
-        timing["load"] += time.perf_counter() - t0
+        for record in _iter_records(cache_file):
+            t0 = time.perf_counter()
+            comp = record["comp"].to(device=device, dtype=param_dtype)
+            logits = mlp(comp)
+            weights = _resolve_weights_from_logits(logits, top_k=top_k)
+            timing["mlp"] += time.perf_counter() - t0
 
-        t0 = time.perf_counter()
-        comp = record["comp"].to(device=device, dtype=param_dtype)
-        logits = mlp(comp)
-        weights = _resolve_weights_from_logits(logits, top_k=top_k)
-        timing["mlp"] += time.perf_counter() - t0
+            t0 = time.perf_counter()
+            energy_preds = record["energy_preds"].to(device=device, dtype=param_dtype)
+            forces_preds = record["forces_preds"].to(device=device, dtype=param_dtype)
+            batch = record["batch"].to(device=device, dtype=torch.long)
+            weighted_energy, weighted_forces = weighted_average(
+                energy_preds, forces_preds, weights, batch
+            )
+            energy_target = record["energy_target"].to(device=device, dtype=param_dtype)
+            forces_target = record["forces_target"].to(device=device, dtype=param_dtype)
+            loss_energy = loss_fn(weighted_energy, energy_target)
+            loss_forces = loss_fn(weighted_forces, forces_target)
+            loss = energy_weight * loss_energy + force_weight * loss_forces
+            timing["loss"] += time.perf_counter() - t0
 
-        t0 = time.perf_counter()
-        energy_preds = record["energy_preds"].to(device=device, dtype=param_dtype)
-        forces_preds = record["forces_preds"].to(device=device, dtype=param_dtype)
-        batch = record["batch"].to(device=device, dtype=torch.long)
-        weighted_energy, weighted_forces = weighted_average(
-            energy_preds, forces_preds, weights, batch
-        )
-        energy_target = record["energy_target"].to(device=device, dtype=param_dtype)
-        forces_target = record["forces_target"].to(device=device, dtype=param_dtype)
-        loss_energy = loss_fn(weighted_energy, energy_target)
-        loss_forces = loss_fn(weighted_forces, forces_target)
-        loss = energy_weight * loss_energy + force_weight * loss_forces
-        timing["loss"] += time.perf_counter() - t0
+            total_loss += loss.item() * int(record["num_graphs"])
+            total_samples += int(record["num_graphs"])
+            total_batches += 1
 
-        num_graphs = int(record["num_graphs"])
-        total_loss += loss.item() * num_graphs
-        total_samples += num_graphs
         timing["total"] += time.perf_counter() - iter_t0
 
-    timing["num_batches"] = max(len(cache_files), 1)
+    timing["num_batches"] = max(total_batches, 1)
     return total_loss / max(total_samples, 1), timing
 
 
@@ -348,11 +365,26 @@ def main():
     parser.add_argument("--oversampling", action="store_true")
     parser.add_argument("--oversampling_num_samples", type=int, default=None)
     parser.add_argument("--preload", action="store_true")
+    parser.add_argument(
+        "--chunk_size",
+        type=int,
+        default=None,
+        help=(
+            "Max samples per dataset per chunk during cache building. "
+            "If None, loads all num_samples at once. "
+            "Use this to avoid OOM on large datasets."
+        ),
+    )
     parser.add_argument("--batch_size", type=int, default=None)
     parser.add_argument("--energy_weight", type=float, default=None)
     parser.add_argument("--force_weight", type=float, default=None)
     parser.add_argument("--output_dir", default="mlp_weights")
     parser.add_argument("--output", default="branch_weight_mlp_cached.pt")
+    parser.add_argument(
+        "--resume_mlp",
+        default=None,
+        help="Path to a saved MLP checkpoint to resume training from",
+    )
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--adios", action="store_const", dest="format", const="adios")
@@ -372,17 +404,25 @@ def main():
     var_config = config["NeuralNetwork"]["Variables_of_interest"]
 
     hydragnn.utils.distributed.setup_ddp()
+    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
 
-    if args.multi_model_list:
-        train_loader, val_loader, _ = load_multidataset_dataloaders(
-            args, config, var_config
-        )
-    else:
-        raise NotImplementedError(
-            "Cached script currently supports multi-dataset mode only"
-        )
+    # Get modellist and pna_deg once from metadata only
+    modellist, pna_deg = get_modellist_and_pna_deg(args, var_config)
 
-    config = update_config(config, train_loader, val_loader, val_loader)
+    # update_config once using a tiny loader from the first dataset
+    args_tiny = copy.copy(args)
+    args_tiny.num_samples = 100
+    args_tiny.preload = False
+    first_train_loader, first_val_loader, _ = load_single_dataset_dataloaders(
+        args_tiny, config, var_config,
+        model_name=modellist[0],
+        model_index=0,
+        modellist=modellist,
+        pna_deg=pna_deg,
+    )
+    config = update_config(config, first_train_loader, first_val_loader, first_val_loader)
+    del first_train_loader, first_val_loader
+    gc.collect()
 
     precision, precision_source = resolve_selected_precision(args.precision, config)
     precision, param_dtype, _ = resolve_precision(precision)
@@ -405,37 +445,102 @@ def main():
         top_k = args.top_k
 
     cache_dtype = _resolve_cache_dtype(args.cache_dtype)
-    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+
     if rank == 0:
         print(f"Using precision={precision} (source={precision_source})")
         print(
-            f"Cached stacking config: num_branches={num_branches}, top_k={top_k}, cache_dtype={cache_dtype}"
+            f"Cached stacking config: num_branches={num_branches}, top_k={top_k}, "
+            f"cache_dtype={cache_dtype}, datasets={len(modellist)}"
         )
 
-    train_cached = _cache_split(
-        model,
-        train_loader,
-        split="train",
-        cache_root=args.cache_dir,
-        num_branches=num_branches,
-        precision=precision,
-        cache_dtype=cache_dtype,
-        rebuild_cache=args.rebuild_cache,
-    )
-    val_cached = _cache_split(
-        model,
-        val_loader,
-        split="val",
-        cache_root=args.cache_dir,
-        num_branches=num_branches,
-        precision=precision,
-        cache_dtype=cache_dtype,
-        rebuild_cache=args.rebuild_cache,
-    )
+    # ------------------------------------------------------------------
+    # Cache building — one dataset at a time, with optional chunking
+    # to avoid OOM on large datasets
+    # ------------------------------------------------------------------
+    total_train_cached = 0
+    total_val_cached = 0
+
+    chunk_size = args.chunk_size or (args.num_samples or 10**9)
+
+    for model_index, model_name in enumerate(modellist):
+        if rank == 0:
+            print(f"Caching dataset {model_index + 1}/{len(modellist)}: {model_name}")
+
+        dataset_cache_dir = os.path.join(args.cache_dir, model_name)
+        out_train = os.path.join(dataset_cache_dir, "train", f"rank{rank:05d}", "batches.pkl")
+        out_val   = os.path.join(dataset_cache_dir, "val",   f"rank{rank:05d}", "batches.pkl")
+
+        # Skip entirely if both splits already cached
+        if (not args.rebuild_cache) and os.path.exists(out_train) and os.path.exists(out_val):
+            n_train = _count_chunks(out_train)
+            n_val   = _count_chunks(out_val)
+            if rank == 0:
+                print(f"  Already cached ({n_train} train chunks, {n_val} val chunks), skipping")
+            total_train_cached += n_train
+            total_val_cached   += n_val
+            if dist.is_available() and dist.is_initialized():
+                dist.barrier()
+            continue
+
+        # Remove partial files if rebuilding
+        if args.rebuild_cache:
+            for p in [out_train, out_val]:
+                if os.path.exists(p):
+                    os.remove(p)
+
+        os.makedirs(os.path.dirname(out_train), exist_ok=True)
+        os.makedirs(os.path.dirname(out_val),   exist_ok=True)
+
+        num_samples = args.num_samples or 10**9
+        train_batches_written = 0
+        val_batches_written   = 0
+
+        for chunk_start in range(0, num_samples, chunk_size):
+            if rank == 0:
+                print(f"  Chunk [{chunk_start} : {chunk_start + chunk_size}]")
+
+            train_loader, val_loader, _ = load_single_dataset_chunk(
+                args, config, var_config,
+                model_name=model_name,
+                model_index=model_index,
+                modellist=modellist,
+                pna_deg=pna_deg,
+                chunk_start=chunk_start,
+                chunk_size=chunk_size,
+            )
+
+            train_records = _collect_records(
+                model, train_loader, num_branches, precision, cache_dtype, param_dtype, device
+            )
+            _append_records(out_train, train_records)
+            train_batches_written += len(train_records)
+
+            val_records = _collect_records(
+                model, val_loader, num_branches, precision, cache_dtype, param_dtype, device
+            )
+            _append_records(out_val, val_records)
+            val_batches_written += len(val_records)
+
+            del train_loader, val_loader, train_records, val_records
+            gc.collect()
+
+            if dist.is_available() and dist.is_initialized():
+                dist.barrier()
+
+        if rank == 0:
+            print(f"  Saved {train_batches_written} train, {val_batches_written} val batches")
+
+        total_train_cached += train_batches_written
+        total_val_cached   += val_batches_written
+
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
 
     if rank == 0:
         print(
-            f"Cache ready under {args.cache_dir}: train_files_per_rank={train_cached}, val_files_per_rank={val_cached}"
+            f"Cache ready under {args.cache_dir}: "
+            f"train_batches_per_rank={total_train_cached}, "
+            f"val_batches_per_rank={total_val_cached}"
         )
 
     if dist.is_available() and dist.is_initialized():
@@ -444,19 +549,62 @@ def main():
     if args.build_cache_only:
         return
 
+    # ------------------------------------------------------------------
+    # MLP training
+    # ------------------------------------------------------------------
     train_cache_files = _get_rank_cache_files(args.cache_dir, split="train")
-    val_cache_files = _get_rank_cache_files(args.cache_dir, split="val")
+    val_cache_files   = _get_rank_cache_files(args.cache_dir, split="val")
     if len(train_cache_files) == 0 or len(val_cache_files) == 0:
         raise RuntimeError("Cache files are missing; run with --rebuild_cache")
+
+    if rank == 0:
+        print(f"MLP training on {len(train_cache_files)} train files, {len(val_cache_files)} val files per rank")
 
     hidden_dims = tuple(int(x) for x in args.hidden_dims.split(",") if x.strip())
     mlp = BranchWeightMLP(None, hidden_dims, num_branches).to(
         device=device, dtype=param_dtype
     )
+
+    # Initialise LazyLinear before wrapping in DDP
+    with torch.no_grad():
+        first_record = next(_iter_records(train_cache_files[0]))
+        sample_comp = first_record["comp"].to(device=device, dtype=param_dtype)
+        _ = mlp(sample_comp)
+
+    # Resume from checkpoint if provided
+    start_epoch = 0
+    os.makedirs(args.output_dir, exist_ok=True)
+    output_path = os.path.join(args.output_dir, args.output)
+    output_stem, _ = os.path.splitext(output_path)
+    timing_path = f"{output_stem}.timing.json"
+
+    if args.resume_mlp is not None and os.path.exists(args.resume_mlp):
+        ckpt_mlp = torch.load(args.resume_mlp, map_location=device)
+        mlp.load_state_dict(ckpt_mlp["mlp_state_dict"])
+        start_epoch = ckpt_mlp.get("epoch", 0)
+        if rank == 0:
+            print(f"Resumed MLP from {args.resume_mlp} at epoch {start_epoch}")
+
+    # Wrap in DDP so all ranks train collectively
+    if dist.is_available() and dist.is_initialized():
+        mlp = DDP(mlp, device_ids=[torch.cuda.current_device()])
+
     optimizer = torch.optim.AdamW(
         mlp.parameters(), lr=args.lr, weight_decay=args.weight_decay
     )
     loss_fn = F.mse_loss
+
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", factor=0.5, patience=10, min_lr=1e-6
+    )
+
+    # Restore optimizer and scheduler state if resuming
+    if args.resume_mlp is not None and os.path.exists(args.resume_mlp):
+        ckpt_mlp = torch.load(args.resume_mlp, map_location=device)
+        if "optimizer_state_dict" in ckpt_mlp:
+            optimizer.load_state_dict(ckpt_mlp["optimizer_state_dict"])
+        if "scheduler_state_dict" in ckpt_mlp:
+            scheduler.load_state_dict(ckpt_mlp["scheduler_state_dict"])
 
     energy_weight = (
         args.energy_weight
@@ -469,35 +617,51 @@ def main():
         else config["NeuralNetwork"]["Architecture"].get("force_weight", 1.0)
     )
 
-    os.makedirs(args.output_dir, exist_ok=True)
-    output_path = os.path.join(args.output_dir, args.output)
-    output_stem, _ = os.path.splitext(output_path)
-    timing_path = f"{output_stem}.timing.json"
+    # Load existing timing history if resuming
     timing_history = []
+    if os.path.exists(timing_path):
+        try:
+            with open(timing_path, "r") as f:
+                timing_history = json.load(f)
+            if rank == 0:
+                print(f"Loaded timing history ({len(timing_history)} epochs) from {timing_path}")
+        except Exception:
+            timing_history = []
 
-    for epoch in range(args.epochs):
+    for epoch in range(start_epoch, start_epoch + args.epochs):
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+
+        # Shuffle dataset order each epoch so MLP sees datasets in different
+        # order — prevents catastrophic forgetting of early datasets.
+        # Seed with epoch so all ranks shuffle identically.
+        random.seed(epoch)
+        random.shuffle(train_cache_files)
+
         train_loss, train_timing = _train_epoch_from_cache(
-            mlp,
-            train_cache_files,
-            optimizer,
-            loss_fn,
-            energy_weight,
-            force_weight,
-            top_k,
-            precision,
+            mlp, train_cache_files, optimizer, loss_fn,
+            energy_weight, force_weight, top_k, precision,
         )
+
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+
         val_loss, val_timing = _validate_epoch_from_cache(
-            mlp,
-            val_cache_files,
-            loss_fn,
-            energy_weight,
-            force_weight,
-            top_k,
-            precision,
+            mlp, val_cache_files, loss_fn,
+            energy_weight, force_weight, top_k, precision,
         )
+
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
 
         train_loss_global = _allreduce_mean(train_loss)
-        val_loss_global = _allreduce_mean(val_loss)
+        val_loss_global   = _allreduce_mean(val_loss)
+
+        scheduler.step(val_loss_global)
+
+        if rank == 0:
+            current_lr = optimizer.param_groups[0]["lr"]
+            print(f"  current_lr={current_lr:.2e}")
 
         timing_history.append(
             {
@@ -505,21 +669,47 @@ def main():
                 "train_loss": float(train_loss_global),
                 "val_loss": float(val_loss_global),
                 "train_timing": {k: float(v) for k, v in train_timing.items()},
-                "val_timing": {k: float(v) for k, v in val_timing.items()},
+                "val_timing":   {k: float(v) for k, v in val_timing.items()},
             }
         )
 
+        # Save after every epoch so progress is never lost
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+
         if rank == 0:
+            mlp_to_save = mlp.module if isinstance(mlp, DDP) else mlp
+            tmp_output = output_path + ".tmp"
+            torch.save(
+                {
+                    "mlp_state_dict": mlp_to_save.state_dict(),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "scheduler_state_dict": scheduler.state_dict(),
+                    "epoch": epoch + 1,
+                },
+                tmp_output,
+            )
+            os.replace(tmp_output, output_path)
+
+            tmp_timing = timing_path + ".tmp"
+            with open(tmp_timing, "w") as f:
+                json.dump(timing_history, f, indent=2)
+            os.replace(tmp_timing, timing_path)
             print(
-                f"Epoch {epoch + 1}/{args.epochs}: train={train_loss_global:.6f} val={val_loss_global:.6f} "
-                f"| train(total={train_timing['total']:.2f}s, load={train_timing['load']:.2f}s, mlp={train_timing['mlp']:.2f}s, loss={train_timing['loss']:.2f}s, opt={train_timing['opt']:.2f}s) "
-                f"| val(total={val_timing['total']:.2f}s, load={val_timing['load']:.2f}s, mlp={val_timing['mlp']:.2f}s, loss={val_timing['loss']:.2f}s)"
+                f"Epoch {epoch + 1}/{start_epoch + args.epochs}: "
+                f"train={train_loss_global:.6f} val={val_loss_global:.6f} "
+                f"| train(total={train_timing['total']:.2f}s, "
+                f"load={train_timing['load']:.2f}s, "
+                f"mlp={train_timing['mlp']:.2f}s, "
+                f"loss={train_timing['loss']:.2f}s, "
+                f"opt={train_timing['opt']:.2f}s) "
+                f"| val(total={val_timing['total']:.2f}s, "
+                f"load={val_timing['load']:.2f}s, "
+                f"mlp={val_timing['mlp']:.2f}s, "
+                f"loss={val_timing['loss']:.2f}s)"
             )
 
-    torch.save({"mlp_state_dict": mlp.state_dict()}, output_path)
     if rank == 0:
-        with open(timing_path, "w") as f:
-            json.dump(timing_history, f, indent=2)
         print(f"Saved cached-MLP weights to {output_path}")
         print(f"Saved cached-MLP timing to {timing_path}")
 

--- a/examples/multidataset_hpo_sc26/utils.py
+++ b/examples/multidataset_hpo_sc26/utils.py
@@ -1,0 +1,559 @@
+import os
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch.utils.data import ConcatDataset
+
+from mpi4py import MPI
+
+from hydragnn.preprocess import create_dataloaders
+
+try:
+    from hydragnn.utils.datasets.adiosdataset import AdiosDataset, adios2_open
+except ImportError:
+    AdiosDataset = None
+    adios2_open = None
+
+
+def cleanup_distributed():
+    if dist.is_available() and dist.is_initialized():
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+
+
+class NormalizedDataset:
+    def __init__(self, base_dataset):
+        self.base_dataset = base_dataset
+
+    def __len__(self):
+        return len(self.base_dataset)
+
+    def __getattr__(self, name):
+        return getattr(self.base_dataset, name)
+
+    @staticmethod
+    def _normalize_graph_tensor(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.dim() == 0:
+            return tensor.view(1, 1)
+        if tensor.dim() == 1:
+            return tensor.unsqueeze(0)
+        return tensor
+
+    def __getitem__(self, index):
+        data = self.base_dataset[index]
+
+        for name in [
+            "chemical_composition",
+            "energy",
+            "energy_per_atom",
+            "y",
+            "graph_attr",
+            "natoms",
+            "pbc",
+        ]:
+            if hasattr(data, name):
+                value = getattr(data, name)
+                if torch.is_tensor(value):
+                    setattr(data, name, self._normalize_graph_tensor(value))
+
+        if hasattr(data, "atomic_numbers"):
+            value = data.atomic_numbers
+            if torch.is_tensor(value):
+                if value.dim() == 0:
+                    data.atomic_numbers = value.view(1)
+                elif value.dim() == 2 and value.size(-1) == 1:
+                    data.atomic_numbers = value.squeeze(-1)
+
+        if hasattr(data, "x"):
+            value = data.x
+            if torch.is_tensor(value) and value.dim() == 1:
+                data.x = value.unsqueeze(-1)
+
+        if hasattr(data, "natoms") and torch.is_tensor(data.natoms):
+            data.natoms = data.natoms.to(dtype=torch.long)
+
+        if hasattr(data, "dataset_name") and torch.is_tensor(data.dataset_name):
+            data.dataset_name = data.dataset_name.to(dtype=torch.long)
+
+        if hasattr(data, "edge_index") and torch.is_tensor(data.edge_index):
+            data.edge_index = data.edge_index.to(dtype=torch.long)
+
+        if hasattr(data, "atomic_numbers") and torch.is_tensor(data.atomic_numbers):
+            data.atomic_numbers = data.atomic_numbers.to(dtype=torch.long)
+
+        if hasattr(data, "chemical_composition") and torch.is_tensor(data.chemical_composition):
+            data.chemical_composition = data.chemical_composition.to(dtype=torch.float32)
+
+        if hasattr(data, "energy") and torch.is_tensor(data.energy):
+            data.energy = data.energy.to(dtype=torch.float32)
+
+        if hasattr(data, "energy_per_atom") and torch.is_tensor(data.energy_per_atom):
+            data.energy_per_atom = data.energy_per_atom.to(dtype=torch.float32)
+
+        if hasattr(data, "forces") and torch.is_tensor(data.forces):
+            data.forces = data.forces.to(dtype=torch.float32)
+
+        if hasattr(data, "pos") and torch.is_tensor(data.pos):
+            data.pos = data.pos.to(dtype=torch.float32)
+
+        if hasattr(data, "graph_attr") and torch.is_tensor(data.graph_attr):
+            data.graph_attr = data.graph_attr.to(dtype=torch.float32)
+
+        if hasattr(data, "y") and torch.is_tensor(data.y):
+            data.y = data.y.to(dtype=torch.float32)
+
+        if hasattr(data, "edge_attr") and torch.is_tensor(data.edge_attr):
+            data.edge_attr = data.edge_attr.to(dtype=torch.float32)
+
+        if hasattr(data, "cell") and torch.is_tensor(data.cell):
+            data.cell = data.cell.to(dtype=torch.float32)
+
+        if hasattr(data, "edge_shifts") and torch.is_tensor(data.edge_shifts):
+            data.edge_shifts = data.edge_shifts.to(dtype=torch.float32)
+
+        if hasattr(data, "pbc") and torch.is_tensor(data.pbc):
+            data.pbc = data.pbc.to(dtype=torch.float32)
+
+        return data
+
+
+def configure_variable_names(config):
+    graph_feature_names = ["energy"]
+    graph_feature_dims = [1]
+    node_feature_names = ["atomic_number", "cartesian_coordinates", "forces"]
+    node_feature_dims = [1, 3, 3]
+    var_config = config["NeuralNetwork"]["Variables_of_interest"]
+    var_config["graph_feature_names"] = graph_feature_names
+    var_config["graph_feature_dims"] = graph_feature_dims
+    var_config["node_feature_names"] = node_feature_names
+    var_config["node_feature_dims"] = node_feature_dims
+    var_config["input_node_features"] = [0]
+
+
+def resolve_selected_precision(args_precision: Optional[str], config: dict) -> Tuple[str, str]:
+    cfg_precision = (
+        config.get("NeuralNetwork", {}).get("Training", {}).get("precision", None)
+    )
+
+    if args_precision is not None:
+        source = "cli"
+        raw_precision = args_precision
+    elif cfg_precision is not None:
+        source = "config.json"
+        raw_precision = cfg_precision
+    else:
+        source = "built-in-default"
+        raw_precision = "fp32"
+
+    value = str(raw_precision).strip().lower()
+    aliases = {
+        "float16": "fp16",
+        "half": "fp16",
+        "float32": "fp32",
+        "single": "fp32",
+        "float64": "fp64",
+        "double": "fp64",
+        "bfloat16": "bf16",
+    }
+    precision = aliases.get(value, value)
+    return precision, source
+
+
+def infer_num_branches(config: dict, model) -> int:
+    arch = config.get("NeuralNetwork", {}).get("Architecture", {})
+    output_heads = arch.get("output_heads", {})
+    graph_heads = output_heads.get("graph") if isinstance(output_heads, dict) else None
+    if isinstance(graph_heads, list) and len(graph_heads) > 0:
+        return len(graph_heads)
+
+    model_num_branches = getattr(model, "num_branches", None)
+    if isinstance(model_num_branches, int) and model_num_branches > 0:
+        return model_num_branches
+
+    return 1
+
+
+def load_multidataset_dataloaders(args, config, var_config):
+    if AdiosDataset is None:
+        raise ImportError("AdiosDataset is unavailable; install adios2 to use --multi")
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    if not args.multi_model_list or args.multi_model_list.strip() == "":
+        raise ValueError("--multi_model_list must be provided")
+
+    modellist = [m for m in args.multi_model_list.split(",") if m.strip()]
+    if len(modellist) == 0:
+        raise ValueError("--multi_model_list resulted in zero entries")
+
+    if rank == 0:
+        pna_deg_list = []
+        for model in modellist:
+            fname = os.path.join(args.dataset_dir, f"{model}-v2.bp")
+            with adios2_open(fname, "r", MPI.COMM_SELF) as f:
+                f.__next__()
+                attrs = f.available_attributes()
+                pna_deg = None
+                if "pna_deg" in attrs:
+                    pna_deg = f.read_attribute("pna_deg")
+                pna_deg_list.append(pna_deg)
+
+        if all(p is None for p in pna_deg_list):
+            pna_deg = None
+        else:
+            valid_pna_deg = [p for p in pna_deg_list if p is not None]
+            intp_list = []
+            mlen = min(len(p) for p in valid_pna_deg)
+            for p in valid_pna_deg:
+                x = np.linspace(0, 1, num=len(p))
+                intp = np.interp(np.linspace(0, 1, num=mlen), x, p)
+                intp_list.append(intp)
+            pna_deg = np.sum(np.stack(intp_list, axis=0), axis=0).astype(np.int64).tolist()
+    else:
+        pna_deg = None
+
+    pna_deg = comm.bcast(pna_deg, root=0)
+
+    common_variable_names = [
+        "pbc",
+        "edge_attr",
+        "energy_per_atom",
+        "forces",
+        "pos",
+        "edge_index",
+        "cell",
+        "edge_shifts",
+        "y",
+        "chemical_composition",
+        "natoms",
+        "x",
+        "energy",
+        "graph_attr",
+        "atomic_numbers",
+    ]
+
+    def build_mixed_split(split_label: str, split_index: int):
+        datasets = []
+        for model_name in modellist:
+            fname = os.path.join(args.dataset_dir, f"{model_name}-v2.bp")
+            dataset = AdiosDataset(
+                fname,
+                split_label,
+                MPI.COMM_WORLD,
+                keys=common_variable_names,
+                var_config=var_config,
+            )
+
+            dataset.dataset_name_dict = {
+                name.lower(): torch.tensor([[i]]) for i, name in enumerate(modellist)
+            }
+
+            dataset_len = len(dataset)
+            subset_len = dataset_len
+            if args.num_samples is not None:
+                requested = args.num_samples if split_index == 0 else max(args.num_samples // 10, 1)
+                subset_len = min(requested, dataset_len)
+
+            dataset.setkeys(common_variable_names)
+            dataset.setsubset(0, subset_len, preload=args.preload)
+            datasets.append(NormalizedDataset(dataset))
+
+            if rank == 0:
+                print(f"Mixed {split_label}: include {model_name} with {subset_len} samples")
+
+        if len(datasets) == 1:
+            return datasets[0]
+        return ConcatDataset(datasets)
+
+    trainset = build_mixed_split("trainset", 0)
+    valset = build_mixed_split("valset", 1)
+    testset = build_mixed_split("testset", 2)
+
+    if pna_deg is not None:
+        trainset.pna_deg = pna_deg
+        valset.pna_deg = pna_deg
+        testset.pna_deg = pna_deg
+
+    train_loader, val_loader, test_loader = create_dataloaders(
+        trainset,
+        valset,
+        testset,
+        config["NeuralNetwork"]["Training"]["batch_size"],
+        test_sampler_shuffle=False,
+        oversampling=False,
+    )
+    comm.Barrier()
+    return train_loader, val_loader, test_loader
+
+
+def load_single_dataset_chunk(
+    args,
+    config,
+    var_config,
+    model_name: str,
+    model_index: int,
+    modellist: list,
+    pna_deg,
+    chunk_start: int,
+    chunk_size: int,
+):
+    """Load one chunk of a single dataset and return train/val loaders.
+
+    Opens the dataset fresh each call so ADIOS2 metadata for previous
+    chunks is released before the next chunk is loaded.
+
+    chunk_start and chunk_size apply to the global sample index space
+    (before rank partitioning by create_dataloaders).
+    """
+    if AdiosDataset is None:
+        raise ImportError("AdiosDataset is unavailable; install adios2 to use --multi")
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    common_variable_names = [
+        "pbc",
+        "edge_attr",
+        "energy_per_atom",
+        "forces",
+        "pos",
+        "edge_index",
+        "cell",
+        "edge_shifts",
+        "y",
+        "chemical_composition",
+        "natoms",
+        "x",
+        "energy",
+        "graph_attr",
+        "atomic_numbers",
+    ]
+
+    fname = os.path.join(args.dataset_dir, f"{model_name}-v2.bp")
+
+    def build_split(split_label: str, split_index: int):
+        dataset = AdiosDataset(
+            fname,
+            split_label,
+            MPI.COMM_WORLD,
+            keys=common_variable_names,
+            var_config=var_config,
+        )
+        dataset.dataset_name_dict = {
+            name.lower(): torch.tensor([[i]]) for i, name in enumerate(modellist)
+        }
+        dataset_len = len(dataset)
+
+        # For val, chunk_size is scaled down proportionally
+        this_chunk_size = chunk_size if split_index == 0 else max(chunk_size // 10, 1)
+        start = min(chunk_start if split_index == 0 else chunk_start // 10, dataset_len)
+        end   = min(start + this_chunk_size, dataset_len)
+
+        if start >= end:
+            start = 0
+            end = min(1, dataset_len)
+
+        dataset.setkeys(common_variable_names)
+        dataset.setsubset(start, end, preload=args.preload)
+
+        if rank == 0:
+            print(f"  {split_label}: {model_name} chunk [{start}:{end}] ({end - start} samples)")
+
+        return NormalizedDataset(dataset)
+
+    trainset = build_split("trainset", 0)
+    valset   = build_split("valset",   1)
+    testset  = build_split("testset",  2)
+
+    if pna_deg is not None:
+        trainset.pna_deg = pna_deg
+        valset.pna_deg   = pna_deg
+        testset.pna_deg  = pna_deg
+
+    train_loader, val_loader, test_loader = create_dataloaders(
+        trainset,
+        valset,
+        testset,
+        config["NeuralNetwork"]["Training"]["batch_size"],
+        test_sampler_shuffle=False,
+        oversampling=False,
+    )
+    comm.Barrier()
+    return train_loader, val_loader, test_loader
+
+
+def load_single_dataset_dataloaders(args, config, var_config, model_name: str, model_index: int, modellist: list, pna_deg):
+    """Load a full dataset (no chunking). Kept for backward compatibility and tiny loaders."""
+    num_samples = getattr(args, "num_samples", None)
+    chunk_start = 0
+    chunk_size  = num_samples if num_samples is not None else 10**9  # effectively all
+
+    return load_single_dataset_chunk(
+        args, config, var_config,
+        model_name=model_name,
+        model_index=model_index,
+        modellist=modellist,
+        pna_deg=pna_deg,
+        chunk_start=chunk_start,
+        chunk_size=chunk_size,
+    )
+
+
+def get_modellist_and_pna_deg(args, var_config):
+    """Read modellist and merged pna_deg from dataset metadata.
+    Call once before the per-dataset loop.
+    """
+    if AdiosDataset is None:
+        raise ImportError("AdiosDataset is unavailable; install adios2 to use --multi")
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    if not args.multi_model_list or args.multi_model_list.strip() == "":
+        raise ValueError("--multi_model_list must be provided")
+
+    modellist = [m for m in args.multi_model_list.split(",") if m.strip()]
+    if len(modellist) == 0:
+        raise ValueError("--multi_model_list resulted in zero entries")
+
+    if rank == 0:
+        pna_deg_list = []
+        for model in modellist:
+            fname = os.path.join(args.dataset_dir, f"{model}-v2.bp")
+            with adios2_open(fname, "r", MPI.COMM_SELF) as f:
+                f.__next__()
+                attrs = f.available_attributes()
+                pna_deg = None
+                if "pna_deg" in attrs:
+                    pna_deg = f.read_attribute("pna_deg")
+                pna_deg_list.append(pna_deg)
+
+        if all(p is None for p in pna_deg_list):
+            pna_deg = None
+        else:
+            valid_pna_deg = [p for p in pna_deg_list if p is not None]
+            intp_list = []
+            mlen = min(len(p) for p in valid_pna_deg)
+            for p in valid_pna_deg:
+                x = np.linspace(0, 1, num=len(p))
+                intp = np.interp(np.linspace(0, 1, num=mlen), x, p)
+                intp_list.append(intp)
+            pna_deg = np.sum(np.stack(intp_list, axis=0), axis=0).astype(np.int64).tolist()
+    else:
+        pna_deg = None
+
+    pna_deg = comm.bcast(pna_deg, root=0)
+    return modellist, pna_deg
+
+
+def build_dataset_name(data, branch_id: int) -> torch.Tensor:
+    if hasattr(data, "dataset_name"):
+        return torch.full_like(data.dataset_name, branch_id)
+    return torch.full((data.num_graphs, 1), branch_id, dtype=torch.long, device=data.x.device)
+
+
+def energy_from_pred(pred) -> torch.Tensor:
+    if isinstance(pred, (list, tuple)):
+        energy = pred[0]
+    elif isinstance(pred, dict) and "graph" in pred:
+        energy = pred["graph"][0]
+    else:
+        energy = pred
+    return energy.squeeze(-1)
+
+
+def predict_branch_energy_forces(model, data, branch_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    original_dataset_name = getattr(data, "dataset_name", None)
+    data.dataset_name = build_dataset_name(data, branch_id)
+
+    pred = model(data)
+    energy_pred = energy_from_pred(pred)
+    forces_pred = torch.autograd.grad(
+        energy_pred,
+        data.pos,
+        grad_outputs=torch.ones_like(energy_pred),
+        retain_graph=False,
+        create_graph=False,
+    )[0]
+    forces_pred = -forces_pred
+
+    if original_dataset_name is None:
+        delattr(data, "dataset_name")
+    else:
+        data.dataset_name = original_dataset_name
+
+    return energy_pred.detach(), forces_pred.detach()
+
+
+def weighted_average(
+    energy_preds: torch.Tensor,
+    forces_preds: torch.Tensor,
+    weights: torch.Tensor,
+    batch: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # Energy: [num_branches, num_graphs] x [num_graphs, num_branches] -> [num_graphs]
+    weighted_energy = torch.sum(weights * energy_preds.transpose(0, 1), dim=1)
+
+    # Forces: vectorized over all branches in one operation
+    # node_weights: [num_atoms, num_branches] — expand per-graph weights to per-atom
+    # forces_preds: [num_branches, num_atoms, 3]
+    # output:       [num_atoms, 3]
+    node_weights = weights[batch]  # [num_atoms, num_branches]
+    weighted_forces = torch.einsum('ab,bac->ac', node_weights, forces_preds)
+
+    return weighted_energy, weighted_forces
+
+
+def extract_dataset_ids(data, num_branches: int) -> torch.Tensor:
+    if not hasattr(data, "dataset_name"):
+        return torch.zeros(data.num_graphs, dtype=torch.long, device=data.batch.device)
+
+    dataset_ids = data.dataset_name
+    if not torch.is_tensor(dataset_ids):
+        dataset_ids = torch.tensor(dataset_ids, dtype=torch.long, device=data.batch.device)
+
+    dataset_ids = dataset_ids.to(device=data.batch.device, dtype=torch.long)
+
+    if dataset_ids.dim() == 0:
+        dataset_ids = dataset_ids.view(1)
+    elif dataset_ids.dim() == 2 and dataset_ids.size(-1) == 1:
+        dataset_ids = dataset_ids.squeeze(-1)
+    elif dataset_ids.dim() > 2:
+        dataset_ids = dataset_ids.view(dataset_ids.size(0), -1)
+        if dataset_ids.size(1) != 1:
+            raise ValueError(f"Unsupported dataset_name shape {tuple(data.dataset_name.shape)}")
+        dataset_ids = dataset_ids.squeeze(-1)
+
+    if dataset_ids.numel() == 1 and data.num_graphs > 1:
+        dataset_ids = dataset_ids.repeat(data.num_graphs)
+
+    if dataset_ids.numel() != data.num_graphs:
+        raise ValueError(
+            f"dataset_name has {dataset_ids.numel()} entries but batch has num_graphs={data.num_graphs}"
+        )
+
+    if torch.any(dataset_ids < 0) or torch.any(dataset_ids >= num_branches):
+        bad_min = int(dataset_ids.min().item())
+        bad_max = int(dataset_ids.max().item())
+        raise ValueError(
+            f"dataset_name IDs out of range [0, {num_branches - 1}]: min={bad_min}, max={bad_max}"
+        )
+
+    return dataset_ids
+
+
+def teacher_from_dataset_id(
+    energy_preds: torch.Tensor,
+    forces_preds: torch.Tensor,
+    batch: torch.Tensor,
+    dataset_ids: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    num_branches = energy_preds.size(0)
+    target_weights = F.one_hot(dataset_ids, num_classes=num_branches).to(dtype=energy_preds.dtype)
+    return weighted_average(energy_preds, forces_preds, target_weights, batch)

--- a/examples/multidataset_hpo_sc26/utils.py
+++ b/examples/multidataset_hpo_sc26/utils.py
@@ -86,8 +86,12 @@ class NormalizedDataset:
         if hasattr(data, "atomic_numbers") and torch.is_tensor(data.atomic_numbers):
             data.atomic_numbers = data.atomic_numbers.to(dtype=torch.long)
 
-        if hasattr(data, "chemical_composition") and torch.is_tensor(data.chemical_composition):
-            data.chemical_composition = data.chemical_composition.to(dtype=torch.float32)
+        if hasattr(data, "chemical_composition") and torch.is_tensor(
+            data.chemical_composition
+        ):
+            data.chemical_composition = data.chemical_composition.to(
+                dtype=torch.float32
+            )
 
         if hasattr(data, "energy") and torch.is_tensor(data.energy):
             data.energy = data.energy.to(dtype=torch.float32)
@@ -135,7 +139,9 @@ def configure_variable_names(config):
     var_config["input_node_features"] = [0]
 
 
-def resolve_selected_precision(args_precision: Optional[str], config: dict) -> Tuple[str, str]:
+def resolve_selected_precision(
+    args_precision: Optional[str], config: dict
+) -> Tuple[str, str]:
     cfg_precision = (
         config.get("NeuralNetwork", {}).get("Training", {}).get("precision", None)
     )
@@ -214,7 +220,9 @@ def load_multidataset_dataloaders(args, config, var_config):
                 x = np.linspace(0, 1, num=len(p))
                 intp = np.interp(np.linspace(0, 1, num=mlen), x, p)
                 intp_list.append(intp)
-            pna_deg = np.sum(np.stack(intp_list, axis=0), axis=0).astype(np.int64).tolist()
+            pna_deg = (
+                np.sum(np.stack(intp_list, axis=0), axis=0).astype(np.int64).tolist()
+            )
     else:
         pna_deg = None
 
@@ -257,7 +265,11 @@ def load_multidataset_dataloaders(args, config, var_config):
             dataset_len = len(dataset)
             subset_len = dataset_len
             if args.num_samples is not None:
-                requested = args.num_samples if split_index == 0 else max(args.num_samples // 10, 1)
+                requested = (
+                    args.num_samples
+                    if split_index == 0
+                    else max(args.num_samples // 10, 1)
+                )
                 subset_len = min(requested, dataset_len)
 
             dataset.setkeys(common_variable_names)
@@ -265,7 +277,9 @@ def load_multidataset_dataloaders(args, config, var_config):
             datasets.append(NormalizedDataset(dataset))
 
             if rank == 0:
-                print(f"Mixed {split_label}: include {model_name} with {subset_len} samples")
+                print(
+                    f"Mixed {split_label}: include {model_name} with {subset_len} samples"
+                )
 
         if len(datasets) == 1:
             return datasets[0]
@@ -353,7 +367,7 @@ def load_single_dataset_chunk(
         # For val, chunk_size is scaled down proportionally
         this_chunk_size = chunk_size if split_index == 0 else max(chunk_size // 10, 1)
         start = min(chunk_start if split_index == 0 else chunk_start // 10, dataset_len)
-        end   = min(start + this_chunk_size, dataset_len)
+        end = min(start + this_chunk_size, dataset_len)
 
         if start >= end:
             start = 0
@@ -363,18 +377,20 @@ def load_single_dataset_chunk(
         dataset.setsubset(start, end, preload=args.preload)
 
         if rank == 0:
-            print(f"  {split_label}: {model_name} chunk [{start}:{end}] ({end - start} samples)")
+            print(
+                f"  {split_label}: {model_name} chunk [{start}:{end}] ({end - start} samples)"
+            )
 
         return NormalizedDataset(dataset)
 
     trainset = build_split("trainset", 0)
-    valset   = build_split("valset",   1)
-    testset  = build_split("testset",  2)
+    valset = build_split("valset", 1)
+    testset = build_split("testset", 2)
 
     if pna_deg is not None:
         trainset.pna_deg = pna_deg
-        valset.pna_deg   = pna_deg
-        testset.pna_deg  = pna_deg
+        valset.pna_deg = pna_deg
+        testset.pna_deg = pna_deg
 
     train_loader, val_loader, test_loader = create_dataloaders(
         trainset,
@@ -388,14 +404,24 @@ def load_single_dataset_chunk(
     return train_loader, val_loader, test_loader
 
 
-def load_single_dataset_dataloaders(args, config, var_config, model_name: str, model_index: int, modellist: list, pna_deg):
+def load_single_dataset_dataloaders(
+    args,
+    config,
+    var_config,
+    model_name: str,
+    model_index: int,
+    modellist: list,
+    pna_deg,
+):
     """Load a full dataset (no chunking). Kept for backward compatibility and tiny loaders."""
     num_samples = getattr(args, "num_samples", None)
     chunk_start = 0
-    chunk_size  = num_samples if num_samples is not None else 10**9  # effectively all
+    chunk_size = num_samples if num_samples is not None else 10 ** 9  # effectively all
 
     return load_single_dataset_chunk(
-        args, config, var_config,
+        args,
+        config,
+        var_config,
         model_name=model_name,
         model_index=model_index,
         modellist=modellist,
@@ -444,7 +470,9 @@ def get_modellist_and_pna_deg(args, var_config):
                 x = np.linspace(0, 1, num=len(p))
                 intp = np.interp(np.linspace(0, 1, num=mlen), x, p)
                 intp_list.append(intp)
-            pna_deg = np.sum(np.stack(intp_list, axis=0), axis=0).astype(np.int64).tolist()
+            pna_deg = (
+                np.sum(np.stack(intp_list, axis=0), axis=0).astype(np.int64).tolist()
+            )
     else:
         pna_deg = None
 
@@ -455,7 +483,9 @@ def get_modellist_and_pna_deg(args, var_config):
 def build_dataset_name(data, branch_id: int) -> torch.Tensor:
     if hasattr(data, "dataset_name"):
         return torch.full_like(data.dataset_name, branch_id)
-    return torch.full((data.num_graphs, 1), branch_id, dtype=torch.long, device=data.x.device)
+    return torch.full(
+        (data.num_graphs, 1), branch_id, dtype=torch.long, device=data.x.device
+    )
 
 
 def energy_from_pred(pred) -> torch.Tensor:
@@ -468,7 +498,9 @@ def energy_from_pred(pred) -> torch.Tensor:
     return energy.squeeze(-1)
 
 
-def predict_branch_energy_forces(model, data, branch_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+def predict_branch_energy_forces(
+    model, data, branch_id: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
     original_dataset_name = getattr(data, "dataset_name", None)
     data.dataset_name = build_dataset_name(data, branch_id)
 
@@ -505,7 +537,7 @@ def weighted_average(
     # forces_preds: [num_branches, num_atoms, 3]
     # output:       [num_atoms, 3]
     node_weights = weights[batch]  # [num_atoms, num_branches]
-    weighted_forces = torch.einsum('ab,bac->ac', node_weights, forces_preds)
+    weighted_forces = torch.einsum("ab,bac->ac", node_weights, forces_preds)
 
     return weighted_energy, weighted_forces
 
@@ -516,7 +548,9 @@ def extract_dataset_ids(data, num_branches: int) -> torch.Tensor:
 
     dataset_ids = data.dataset_name
     if not torch.is_tensor(dataset_ids):
-        dataset_ids = torch.tensor(dataset_ids, dtype=torch.long, device=data.batch.device)
+        dataset_ids = torch.tensor(
+            dataset_ids, dtype=torch.long, device=data.batch.device
+        )
 
     dataset_ids = dataset_ids.to(device=data.batch.device, dtype=torch.long)
 
@@ -527,7 +561,9 @@ def extract_dataset_ids(data, num_branches: int) -> torch.Tensor:
     elif dataset_ids.dim() > 2:
         dataset_ids = dataset_ids.view(dataset_ids.size(0), -1)
         if dataset_ids.size(1) != 1:
-            raise ValueError(f"Unsupported dataset_name shape {tuple(data.dataset_name.shape)}")
+            raise ValueError(
+                f"Unsupported dataset_name shape {tuple(data.dataset_name.shape)}"
+            )
         dataset_ids = dataset_ids.squeeze(-1)
 
     if dataset_ids.numel() == 1 and data.num_graphs > 1:
@@ -555,5 +591,7 @@ def teacher_from_dataset_id(
     dataset_ids: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     num_branches = energy_preds.size(0)
-    target_weights = F.one_hot(dataset_ids, num_classes=num_branches).to(dtype=energy_preds.dtype)
+    target_weights = F.one_hot(dataset_ids, num_classes=num_branches).to(
+        dtype=energy_preds.dtype
+    )
     return weighted_average(energy_preds, forces_preds, target_weights, batch)


### PR DESCRIPTION
This has several changes.
- Data is now read in chunks to avoid OOM.
- DDP around the MLP
- ADIOS fix in utils.py to use MPI.COMM_WORLD instead of MPI.COMM_SELF to improve performance.
- Inference using HydraGNN is performed as a separate step and all output is cached.
- Restart capabilities for resuming inference from a previously interrupted job.

- MLP training also has restart capabilities from a previous epoch.
- Data is reshuffled at the beginning of an epoch to avoid 'forgetting'.
- Learning rate is dynamically changed during runtime if loss plateaus.

# DETAILED CHANGES

# Code Change Log — Branch Weighting MLP
## Files modified: `utils.py`, `branch_weighting_mlp_cached.py`
---

## `utils.py`

### 1. `AdiosDataset` communicator changed from `MPI.COMM_SELF` to `MPI.COMM_WORLD`
**Location:** `load_multidataset_dataloaders` → `build_mixed_split`
**Reason:** With `MPI.COMM_SELF`, every rank independently opened the same `.bp` file
and read its own slice, causing a thundering herd of small random Lustre reads
that dominated runtime (~170s/batch). `MPI.COMM_WORLD` enables collective I/O
where ADIOS2 coordinates reads across ranks, dramatically improving throughput
(~3.4s/batch, ~50× speedup).

### 2. `weighted_average` vectorized using `torch.einsum`
**Location:** `weighted_average` function
**Reason:** The original implementation looped over 16 branches in Python:
```python
for branch_idx in range(energy_preds.size(0)):
    node_weights = torch.repeat_interleave(weights[:, branch_idx], node_counts)
    weighted_forces += node_weights.unsqueeze(-1) * forces_preds[branch_idx]
```
This launched 16 sequential GPU kernels per batch. Replaced with:
```python
node_weights = weights[batch]  # [num_atoms, num_branches]
weighted_forces = torch.einsum('ab,bac->ac', node_weights, forces_preds)
```
One GPU kernel instead of 16. Cut loss computation time from ~21s to ~5s per epoch (~4× speedup).

### 3. New function: `get_modellist_and_pna_deg`
**Reason:** Reads model list and pna_deg metadata once from all dataset files
without loading any sample data. Used before the per-dataset cache loop so
metadata is available without keeping all datasets open simultaneously.

### 4. New function: `load_single_dataset_dataloaders`
**Reason:** Loads a single named dataset (train/val/test splits) at a time.
Enables the per-dataset cache building loop which keeps only one dataset's
metadata and preloaded tensors in RAM at a time, avoiding OOM from loading
all 14 datasets simultaneously.

### 5. New function: `load_single_dataset_chunk`
**Reason:** Like `load_single_dataset_dataloaders` but accepts `chunk_start`
and `chunk_size` parameters to load a subset window of a dataset. Used to
handle large datasets (e.g. OC2022) that OOM even when loaded one at a time
by breaking them into smaller chunks. Opens dataset fresh each call to avoid
ADIOS2 handle invalidation across `setsubset` calls.

---

## `branch_weighting_mlp_cached.py`
This file was written from scratch as a new script. Key design decisions and
features relative to the original `branch_weighting_mlp.py`:

### Core architecture

#### 1. Branch prediction cache
HydraGNN inference (16 branch forward passes + autograd force computation)
is run **once** and results saved to disk. MLP training reads from cache,
never calling HydraGNN again. For N epochs this reduces HydraGNN inference
cost by N×.

#### 2. Per-dataset sequential loading
Instead of loading all 14 datasets into RAM simultaneously, datasets are
loaded one at a time:
```
for each dataset:
    load dataset (with --preload for RAM caching)
    run HydraGNN inference → write cache
    delete dataset
    move to next
```
At any point only one dataset's metadata and tensors are in RAM.

#### 3. Chunked loading for large datasets
Large datasets (OC2020, OC2022) can OOM even when loaded individually.
`--chunk_size` breaks each dataset into smaller windows processed
sequentially. Cache results are appended to a single file per dataset
using pickle append mode.

#### 4. Single file per rank per dataset
Cache is stored as one `batches.pkl` file per rank per dataset:
```
branch_cache/Alexandria/train/rank00000/batches.pkl
branch_cache/ANI1x/train/rank00000/batches.pkl
...
```
This reduces file count from `num_batches × num_ranks × num_datasets` to
`num_ranks × num_datasets` — a 25× reduction that alleviates Lustre
metadata pressure.

#### 5. Pickle append for streaming writes
Records are written chunk-by-chunk using `pickle.dump` in append mode
(`"ab"`), avoiding RAM accumulation across chunks. MLP training reads
back using a generator (`_iter_records`) that streams one chunk at a
time, so full dataset predictions never need to be in RAM simultaneously.

#### 6. Resume logic for cache building
Before running HydraGNN inference for a dataset, checks if
`batches.pkl` already exists. If yes, skips that dataset entirely.
This allows job resubmission to pick up where a previous job left off
without redoing completed datasets.

### MLP training improvements

#### 7. DDP wrapping for MLP
The MLP is wrapped in `DistributedDataParallel` so all ranks train
collectively. Without this, each rank trains independently on its own
data slice and only rank 0's weights (covering 1/N of the data) get
saved. LazyLinear is initialized before DDP wrapping to avoid DDP
missing uninitialized parameters.

#### 8. Barriers between epochs
Three `dist.barrier()` calls per epoch: before train, between train
and val, after val. Plus a final barrier before saving. This prevents
the rank synchronization crash where rank 0 finishes and tears down
the process group while other ranks are still iterating.

#### 9. Dataset shuffle between epochs
Cache files are shuffled at the start of each epoch using
`random.seed(epoch)` so all ranks shuffle identically. Prevents
catastrophic forgetting where the MLP overwrites knowledge of early
datasets (Alexandria) by the time it finishes training on the last one
(transition1x).

#### 10. Resume MLP training (`--resume_mlp`)
Loads MLP weights, optimizer state, scheduler state, and epoch number
from a previous checkpoint. Timing history is also loaded and appended
to, giving a continuous loss curve across job submissions. Auto-detect
in `run-mlp.sl` finds the most recent `.pt` file automatically.

#### 11. Per-epoch checkpoint save
Saves after every epoch rather than only at the end. Uses atomic
write (`torch.save` to `.tmp` then `os.replace`) to avoid corrupt
files if the job is killed mid-write. Only rank 0 saves.

#### 12. Learning rate scheduler
`ReduceLROnPlateau` with `factor=0.5, patience=10, min_lr=1e-6`.
Halves the learning rate when val loss stops improving for 10 epochs.
Scheduler state is saved and restored across job submissions.
Current LR is printed after each epoch.

#### 13. `--build_cache_only` flag
Exits after cache building without starting MLP training. Useful for
building the cache in a long job, then training the MLP in separate
shorter jobs.
