### PR TITLE
fix: set CUDA device before init_process_group; use_orig_params for FSDP v1

### DIFF
--- a/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
+++ b/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
@@ -177,6 +177,7 @@ if __name__ == "__main__":
     parser.add_argument("--correlation", type=int, help="correlation", default=None)
     parser.add_argument("--nvme", action="store_true", help="use NVME")
     parser.add_argument("--startfrom", type=str, help="startfrom", default=None)
+    parser.add_argument("--datadir", type=str, help="path to directory containing .bp dataset files", default=None)
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -209,7 +210,7 @@ if __name__ == "__main__":
     node_feature_names = ["atomic_number", "cartesian_coordinates", "forces"]
     node_feature_dims = [1, 3, 3]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
-    datadir = os.path.join(dirpwd, "dataset")
+    datadir = args.datadir if args.datadir is not None else os.path.join(dirpwd, "dataset")
     ##################################################################################################################
     input_filename = os.path.join(dirpwd, args.inputfile)
     ##################################################################################################################
@@ -425,9 +426,7 @@ if __name__ == "__main__":
             ndata_list = list()
             pna_deg_list = list()
             for model in modellist:
-                fname = os.path.join(
-                    os.path.dirname(__file__), "./dataset/%s-v2.bp" % model
-                )
+                fname = os.path.join(datadir, "%s-v2.bp" % model)
                 with adios2_open(fname, "r", MPI.COMM_SELF) as f:
                     f.__next__()
                     ndata = f.read_attribute("trainset/ndata").item()
@@ -595,7 +594,7 @@ if __name__ == "__main__":
         local_comm_rank = local_comm.Get_rank()
         local_comm_size = local_comm.Get_size()
 
-        fname = os.path.join(os.path.dirname(__file__), "./dataset/%s-v2.bp" % mymodel)
+        fname = os.path.join(datadir, "%s-v2.bp" % mymodel)
 
         ## FIXME: only for Frontier NVME
         bbpath = f"/mnt/bb/{os.getenv('USER')}"
@@ -823,9 +822,7 @@ if __name__ == "__main__":
         ## No DDStore. Each process opens multiple adios files.
         filename_list = list()
         for model in modellist:
-            fname = os.path.join(
-                os.path.dirname(__file__), "./dataset/%s-v2.bp" % model
-            )
+            fname = os.path.join(datadir, "%s-v2.bp" % model)
             filename_list.append(fname)
 
         kwargs = {"var_config": var_config, "keys": common_variable_names}

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -230,6 +230,16 @@ def setup_ddp(use_deepspeed=False):
                 ## Setting LOCAL_RANK complicts with DeviceMesh when using the srun "--gpus-per-task=1" option
                 # os.environ["LOCAL_RANK"] = str(get_local_rank())
 
+            # Set the CUDA device for this rank BEFORE init_process_group so
+            # that the NCCL communicator created by init_process_group (comm '0')
+            # uses the correct per-rank GPU.  Without this, all ranks may use
+            # CUDA device 0, causing FSDP v2's per-rank device keys to mismatch
+            # comm '0' and trigger a new comm ('1') → store-key deadlock.
+            if backend == "nccl" and torch.cuda.is_available():
+                local_rank = get_local_rank()
+                if local_rank < torch.cuda.device_count():
+                    torch.cuda.set_device(local_rank)
+
             if (backend == "gloo") and ("GLOO_SOCKET_IFNAME" not in os.environ):
                 ifname = find_ifname(master_addr)
                 if ifname is not None:
@@ -393,6 +403,7 @@ def is_model_distributed(model):
     return isinstance(model, torch.nn.parallel.distributed.DistributedDataParallel)
 
 
+
 def get_distributed_model(
     model,
     verbosity=0,
@@ -447,7 +458,7 @@ def get_distributed_model(
         if use_fsdp:
             if fsdp_version == 1:
                 print_distributed(verbosity, "Using FSDP v1 wrapper")
-                model = FSDP(model, sharding_strategy=sharding_strategy)
+                model = FSDP(model, sharding_strategy=sharding_strategy, use_orig_params=True)
             else:
                 if fsdp_strategy not in ["FULL_SHARD", "SHARD_GRAD_OP"]:
                     raise ValueError(


### PR DESCRIPTION
## Summary

- **Bug fix**: Call `torch.cuda.set_device(local_rank)` before `init_process_group` in `setup_ddp()`. We observed consistent hangs with FSDP v2 + `SHARD_GRAD_OP` on 4× A100 nodes at NERSC Perlmutter that were resolved by adding this call. Our best guess is that without it, ranks may share CUDA device 0 at NCCL communicator init time, causing a mismatch when FSDP v2 creates per-rank device-specific communicators — but we haven't fully traced the root cause. Adding `set_device` before `init_process_group` is good practice regardless.
- **FSDP v1 `use_orig_params=True`**: Needed for `torch.autograd.grad()` to work through FSDP-sharded parameters (e.g. force prediction via `-∇E`). Note this does not resolve all FSDP v1 issues we observed with energy-force models on Perlmutter — FSDP v2 is the recommended path for force prediction. Still worth including as a correctness improvement for workflows that use `autograd.grad()` under FSDP v1.
- **`--datadir` argument**: Add optional `--datadir` CLI argument to `gfm_mlip_all_mpnn.py`, defaulting to the original `./dataset/` path.

## Testing

We have an FSDP correctness test suite covering loss and gradient correctness for both FSDP v1 and v2, with and without force prediction. On 4× A100 (Perlmutter, SLURM job 51850250): 13 passed, 1 skipped. The skipped test is gradient correctness for FSDP v1 + force prediction: the two-phase backward (`autograd.grad` for forces followed by `loss.backward`) conflicts with FSDP v1's post-backward hooks, leaving gradients unavailable — a fundamental incompatibility rather than a gap we expect to close. Loss correctness for FSDP v1 + forces is still verified. FSDP v2 gradient correctness with force prediction is verified and passes.

We are working on adapting this test suite to HydraGNN's testing conventions before upstreaming it in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)